### PR TITLE
use file of the same name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn recursive_read(pp: &mut Vec<u8>, buffer: &mut Vec<u8>, filepath: &Path) {
                 file.read_to_end(&mut text).unwrap_or_else(|e| {
                     panic!("couldn't read file {}: {}", e, filepath.display());
                 });;
-                let asset_name = path.file_name().unwrap().to_str().unwrap().replace(".", "_").replace("/", "_");
+                let asset_name = path.to_str().unwrap().replace(".", "_").replace("/", "_");
                 write!(pp, "{}", "    \"");
                 write!(pp, "{}", path.display());
                 write!(pp, "{}", "\"");


### PR DESCRIPTION
Hi

I will use files of the same name.
direct access value name change to include all path string.

```
$ tree
.
├── assets.rs
├── main.rs
└── sample1
    ├── hello.txt
    ├── sample2
    │   └── hello.txt
    └── world.txt
```

```
$ rustc main.rs
assets.rs:4:1: 4:99 error: a value named `hello_txt` has already been defined in this module [E0428]
assets.rs:4 pub static hello_txt: [u8; 14] = [72, 101, 108, 108, 111, 32, 83, 97, 109, 112, 108, 101, 50, 10];
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
assets.rs:4:1: 4:99 help: run `rustc --explain E0428` to see a detailed explanation
assets.rs:2:1: 2:99 note: previous definition of `hello_txt` here
assets.rs:2 pub static hello_txt: [u8; 14] = [72, 101, 108, 108, 111, 32, 83, 97, 109, 112, 108, 101, 49, 10];
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to previous error
```

```
$ head assets.rs
#[allow(non_upper_case_globals)]
pub static hello_txt: [u8; 14] = [72, 101, 108, 108, 111, 32, 83, 97, 109, 112, 108, 101, 49, 10];
#[allow(non_upper_case_globals)]
pub static hello_txt: [u8; 14] = [72, 101, 108, 108, 111, 32, 83, 97, 109, 112, 108, 101, 50, 10];
#[allow(non_upper_case_globals)]
pub static world_txt: [u8; 12] = [72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 10];

pub fn get(name: &str) -> Result<&[u8], &str> {
  match name {
    "sample1/hello.txt" => Result::Ok(&hello_txt),
```

change to

```
$ head newassets.rs
#[allow(non_upper_case_globals)]
pub static sample1_hello_txt: [u8; 14] = [72, 101, 108, 108, 111, 32, 83, 97, 109, 112, 108, 101, 49, 10];
#[allow(non_upper_case_globals)]
pub static sample1_sample2_hello_txt: [u8; 14] = [72, 101, 108, 108, 111, 32, 83, 97, 109, 112, 108, 101, 50, 10];
#[allow(non_upper_case_globals)]
pub static sample1_world_txt: [u8; 12] = [72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 10];

pub fn get(name: &str) -> Result<&[u8], &str> {
  match name {
    "sample1/hello.txt" => Result::Ok(&sample1_hello_txt),
```

Sorry for my broken English.

Regards,
