### PR TITLE
Add #![allow(clippy)] to generated file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,8 @@ fn main() {
     let mut list: Vec<u8> = vec![];
 
     write!(output_buffer, "#![allow(dead_code)]");
-    write!(output_buffer, "#![allow(non_upper_case_globals)]\n");
+    write!(output_buffer, "#![allow(non_upper_case_globals)]");
+    write!(output_buffer, "#![allow(clippy)]\n");
     write!(list, "{}", "\npub fn list() -> Vec<&'static str> {\n  vec![\n");
     write!(pp, "{}", "\npub fn get(name: &str) -> Result<&[u8], &str> {\n  match name {\n");
     recursive_read(&mut list, &mut pp, &mut output_buffer, Path::new(input_folder));

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,7 @@ fn main() {
 
     write!(output_buffer, "#![allow(dead_code)]");
     write!(output_buffer, "#![allow(non_upper_case_globals)]");
+    write!(output_buffer, "#![allow(unknown_lints)]");
     write!(output_buffer, "#![allow(clippy)]\n");
     write!(list, "{}", "\npub fn list() -> Vec<&'static str> {\n  vec![\n");
     write!(pp, "{}", "\npub fn get(name: &str) -> Result<&[u8], &str> {\n  match name {\n");


### PR DESCRIPTION
As Clippy is a widely used tool, I think it would be good to ignore clippy warnings on the generated file by default.