### PR TITLE
Uses $crate variable so embed! works in external macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub fn generate_assets<'a>(parent_path: String) -> Asset {
 
 #[macro_export]
 macro_rules! embed {
-    ($x:expr) => ( ::generate_assets($x) )
+    ($x:expr) => ( $crate::generate_assets($x) )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Problem: When trying to use embed!() in an external macro, generate_assets cannot be found because it is looking in root (::generate_assets($x))
```
error[E0425]: cannot find function `generate_assets` in the crate root
  --> src/main.rs:47:5
   |
47 |     builtins!();
   |     ^^^^^^^^^^^^ not found in the crate root
   |
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
help: possible candidate is found in another module, you can import it into scope
   |
25 | use rust_embed::generate_assets;
   |

error: aborting due to previous error

error: Could not compile `test_proj`.

To learn more, run the command again with --verbose.
```

Solution: use **$crate** variable.
See [the-variable-crate](https://doc.rust-lang.org/1.7.0/book/macros.html#the-variable-crate) for more details.

Thanks!
-jgrowl
