### PR TITLE
Use standard logging in debug mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,11 @@ fn generate_assets(ident: &syn::Ident, folder_path: String) -> quote::Tokens {
               let name = &format!("{}{}", folder_path, file_path);
               let path = &Path::new(name);
               let key = String::from(path.to_str().expect("Path does not have a string representation"));
-              info!("file: {}", key);
+              println!("file: {}", key);
               let mut file = match File::open(path) {
                   Ok(mut file) => file,
                   Err(e) => {
-                      error!("file: {} {}", key, e);
+                      eprintln!("file: {} {}", key, e);
                       return None
                   }
               };
@@ -37,7 +37,7 @@ fn generate_assets(ident: &syn::Ident, folder_path: String) -> quote::Tokens {
               match file.read_to_end(&mut data) {
                   Ok(_) => Some(data),
                   Err(e) =>  {
-                      error!("file: {} {}", key, e);
+                      eprintln!("file: {} {}", key, e);
                       return None
                   }
               }


### PR DESCRIPTION
In debug mode, the `quote!`'d code is not guarrenteed to have access to the `log` macros, and in some cases the macros may be completely different (Rocket has its own `error!` macro).

Solution: change `info` to `println` and `error` to `eprintln`.

Note: The build is broken because the Cargo.lock file is out of date, but #11 fixes that.