### PR TITLE
Move the debug mode use statments into `get`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,12 +15,12 @@ use quote::Tokens;
 #[cfg(debug_assertions)]
 fn generate_assets(ident: &syn::Ident, folder_path: String) -> quote::Tokens {
   quote!{
-      use std::fs::File;
-      use std::io::Read;
-      use std::path::Path;
-
       impl #ident {
           pub fn get(file_path: &str) -> Option<Vec<u8>> {
+              use std::fs::File;
+              use std::io::Read;
+              use std::path::Path;
+
               let folder_path = #folder_path;
               let name = &format!("{}{}", folder_path, file_path);
               let path = &Path::new(name);


### PR DESCRIPTION
When the use statements are ouside of the implementation, the imports can conflict with the deriving code's imports. For example, if some code using rust-embed also imports `Path`, there will be an error because `Path` was imported twice.

Note: The build is broken because the Cargo.lock file is out of date, but #11 fixes that.