### PR TITLE
Complete the example for actix-web

### DIFF
--- a/examples/actix.rs
+++ b/examples/actix.rs
@@ -1,13 +1,38 @@
 extern crate actix_web;
-use actix_web::{server, App, HttpRequest};
+#[macro_use]
+extern crate rust_embed;
 
-fn index(_req: HttpRequest) -> &'static str {
-    "Hello world!"
+use actix_web::{App, HttpRequest, HttpResponse, server};
+use actix_web::http::Method;
+
+#[derive(RustEmbed)]
+#[folder = "examples/public/"]
+struct Asset;
+
+fn handle_embedded_file(path: &str) -> HttpResponse {
+  match Asset::get(path) {
+    Some(content) => HttpResponse::Ok().body(content),
+    None => HttpResponse::NotFound().body("404 Not Found"),
+  }
+}
+
+fn index(_req: HttpRequest) -> HttpResponse {
+  handle_embedded_file("index.html")
+}
+
+fn dist(req: HttpRequest) -> HttpResponse {
+  let path = &req.path()["/dist/".len()..];
+  handle_embedded_file(path)
 }
 
 fn main() {
-    server::new(|| App::new().resource("/", |r| r.f(index)))
-        .bind("127.0.0.1:8000")
-        .unwrap()
-        .run();
+  server::new(|| {
+    App::new().route("/", Method::GET, index).route(
+      "/dist{_:.*}",
+      Method::GET,
+      dist,
+    )
+  }).bind("127.0.0.1:8000")
+    .unwrap()
+    .run();
 }


### PR DESCRIPTION
Hi.
The example for actix-web (*examples/actix.rs*) is not actually implemented yet. I complete that example by following the behavior of *examples/rocket.rs* except that `Content-Type` is not set because actix-web does not have built-in support for inferring `content-type` from file extension and it is unavoidable to import another crate, to which I think be unnecessary.
I have tested it and ensure it works as expected.