### PR TITLE
Improve actix-web example: set content-type, update actix-web to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ syn = "0.11"
 quote = "0.3"
 walkdir = "2.1.4"
 
-actix-web = { version = "0.6", optional = true }
+actix-web = { version = "0.7", optional = true }
+mime_guess = { version = "2.0.0-alpha.6", optional = true }
 
 rocket = { version = "0.3.6", optional = true }
 rocket_codegen = { version = "0.3.6", optional = true }
@@ -26,7 +27,7 @@ rocket_contrib = { version = "0.3.6", optional = true }
 
 [features]
 nightly = ["rocket", "rocket_codegen", "rocket_contrib"]
-actix = ["actix-web"]
+actix = ["actix-web", "mime_guess"]
 
 [badges]
 appveyor = { repository = "pyros2097/rust-embed" }

--- a/examples/actix.rs
+++ b/examples/actix.rs
@@ -1,9 +1,11 @@
 extern crate actix_web;
 #[macro_use]
 extern crate rust_embed;
+extern crate mime_guess;
 
 use actix_web::{App, HttpRequest, HttpResponse, server};
 use actix_web::http::Method;
+use mime_guess::guess_mime_type;
 
 #[derive(RustEmbed)]
 #[folder = "examples/public/"]
@@ -11,7 +13,11 @@ struct Asset;
 
 fn handle_embedded_file(path: &str) -> HttpResponse {
   match Asset::get(path) {
-    Some(content) => HttpResponse::Ok().body(content),
+    Some(content) => {
+      HttpResponse::Ok()
+        .content_type(guess_mime_type(path).as_ref())
+        .body(content)
+    }
     None => HttpResponse::NotFound().body("404 Not Found"),
   }
 }
@@ -21,14 +27,14 @@ fn index(_req: HttpRequest) -> HttpResponse {
 }
 
 fn dist(req: HttpRequest) -> HttpResponse {
-  let path = &req.path()["/dist/".len()..];
+  let path = &req.path()["/dist/".len()..]; // trim the preceding `/dist/` in path
   handle_embedded_file(path)
 }
 
 fn main() {
   server::new(|| {
     App::new().route("/", Method::GET, index).route(
-      "/dist{_:.*}",
+      "/dist/{_:.*}",
       Method::GET,
       dist,
     )


### PR DESCRIPTION
Hi.
I just learned how to use optional dependency and feature mechanisms from your Cargo.toml. : )
So I add *mime_guess* as the optional dependency (because *actix-web* does not have built-in support for guessing mime type from file names) and set `content-type` header in the example of *actix-web*.