### PR TITLE
handle windows paths and add appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,21 +40,21 @@ environment:
   # Stable 64-bit MSVC
     - channel: stable
       target: x86_64-pc-windows-msvc
-  # Stable 32-bit MSVC
-    - channel: stable
-      target: i686-pc-windows-msvc
-  # Beta 64-bit MSVC
-    - channel: beta
-      target: x86_64-pc-windows-msvc
-  # Beta 32-bit MSVC
-    - channel: beta
-      target: i686-pc-windows-msvc
-  # Nightly 64-bit MSVC
-    - channel: nightly
-      target: x86_64-pc-windows-msvc
-  # Nightly 32-bit MSVC
-    - channel: nightly
-      target: i686-pc-windows-msvc
+  # # Stable 32-bit MSVC
+  #   - channel: stable
+  #     target: i686-pc-windows-msvc
+  # # Beta 64-bit MSVC
+  #   - channel: beta
+  #     target: x86_64-pc-windows-msvc
+  # # Beta 32-bit MSVC
+  #   - channel: beta
+  #     target: i686-pc-windows-msvc
+  # # Nightly 64-bit MSVC
+  #   - channel: nightly
+  #     target: x86_64-pc-windows-msvc
+  # # Nightly 32-bit MSVC
+  #   - channel: nightly
+  #     target: i686-pc-windows-msvc
 
 ### GNU Toolchains ###
 
@@ -62,26 +62,26 @@ environment:
     - channel: stable
       target: x86_64-pc-windows-gnu
       MSYS_BITS: 64
-  # Stable 32-bit GNU
-    - channel: stable
-      target: i686-pc-windows-gnu
-      MSYS_BITS: 32
-  # Beta 64-bit GNU
-    - channel: beta
-      target: x86_64-pc-windows-gnu
-      MSYS_BITS: 64
-  # Beta 32-bit GNU
-    - channel: beta
-      target: i686-pc-windows-gnu
-      MSYS_BITS: 32
-  # Nightly 64-bit GNU
-    - channel: nightly
-      target: x86_64-pc-windows-gnu
-      MSYS_BITS: 64
-  # Nightly 32-bit GNU
-    - channel: nightly
-      target: i686-pc-windows-gnu
-      MSYS_BITS: 32
+  # # Stable 32-bit GNU
+  #   - channel: stable
+  #     target: i686-pc-windows-gnu
+  #     MSYS_BITS: 32
+  # # Beta 64-bit GNU
+  #   - channel: beta
+  #     target: x86_64-pc-windows-gnu
+  #     MSYS_BITS: 64
+  # # Beta 32-bit GNU
+  #   - channel: beta
+  #     target: i686-pc-windows-gnu
+  #     MSYS_BITS: 32
+  # # Nightly 64-bit GNU
+  #   - channel: nightly
+  #     target: x86_64-pc-windows-gnu
+  #     MSYS_BITS: 64
+  # # Nightly 32-bit GNU
+  #   - channel: nightly
+  #     target: i686-pc-windows-gnu
+  #     MSYS_BITS: 32
 
 ### Allowed failures ###
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,31 +51,37 @@ environment:
       target: i686-pc-windows-msvc
   # Nightly 64-bit MSVC
     - channel: nightly
-      target: x86_64-pc-windows-msvc      
+      target: x86_64-pc-windows-msvc
   # Nightly 32-bit MSVC
     - channel: nightly
-      target: i686-pc-windows-msvc      
+      target: i686-pc-windows-msvc
 
 ### GNU Toolchains ###
 
   # Stable 64-bit GNU
     - channel: stable
       target: x86_64-pc-windows-gnu
+      MSYS_BITS: 64
   # Stable 32-bit GNU
     - channel: stable
       target: i686-pc-windows-gnu
+      MSYS_BITS: 32
   # Beta 64-bit GNU
     - channel: beta
       target: x86_64-pc-windows-gnu
+      MSYS_BITS: 64
   # Beta 32-bit GNU
     - channel: beta
       target: i686-pc-windows-gnu
+      MSYS_BITS: 32
   # Nightly 64-bit GNU
     - channel: nightly
-      target: x86_64-pc-windows-gnu      
+      target: x86_64-pc-windows-gnu
+      MSYS_BITS: 64
   # Nightly 32-bit GNU
     - channel: nightly
-      target: i686-pc-windows-gnu      
+      target: i686-pc-windows-gnu
+      MSYS_BITS: 32
 
 ### Allowed failures ###
 
@@ -101,6 +107,7 @@ install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %target%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - if defined MSYS_BITS set PATH=C:\msys64\mingw%MSYS_BITS%\bin;C:\msys64\usr\bin;%PATH%
   - rustc -vV
   - cargo -vV
 
@@ -117,6 +124,6 @@ test_script:
   - cargo test --test lib
   - cargo test --test lib --release
   - cargo build --example basic
-  - cargo build --example basic --release 
+  - cargo build --example basic --release
   - cargo build --example actix --features actix
   - cargo build --example actix --features actix --release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,122 @@
+# Appveyor configuration template for Rust using rustup for Rust installation
+# https://github.com/starkat99/appveyor-rust
+
+## Operating System (VM environment) ##
+
+# Rust needs at least Visual Studio 2013 Appveyor OS for MSVC targets.
+os: Visual Studio 2015
+
+## Build Matrix ##
+
+# This configuration will setup a build for each channel & target combination (12 windows
+# combinations in all).
+#
+# There are 3 channels: stable, beta, and nightly.
+#
+# Alternatively, the full version may be specified for the channel to build using that specific
+# version (e.g. channel: 1.5.0)
+#
+# The values for target are the set of windows Rust build targets. Each value is of the form
+#
+# ARCH-pc-windows-TOOLCHAIN
+#
+# Where ARCH is the target architecture, either x86_64 or i686, and TOOLCHAIN is the linker
+# toolchain to use, either msvc or gnu. See https://www.rust-lang.org/downloads.html#win-foot for
+# a description of the toolchain differences.
+# See https://github.com/rust-lang-nursery/rustup.rs/#toolchain-specification for description of
+# toolchains and host triples.
+#
+# Comment out channel/target combos you do not wish to build in CI.
+#
+# You may use the `cargoflags` and `RUSTFLAGS` variables to set additional flags for cargo commands
+# and rustc, respectively. For instance, you can uncomment the cargoflags lines in the nightly
+# channels to enable unstable features when building for nightly. Or you could add additional
+# matrix entries to test different combinations of features.
+environment:
+  matrix:
+
+### MSVC Toolchains ###
+
+  # Stable 64-bit MSVC
+    - channel: stable
+      target: x86_64-pc-windows-msvc
+  # Stable 32-bit MSVC
+    - channel: stable
+      target: i686-pc-windows-msvc
+  # Beta 64-bit MSVC
+    - channel: beta
+      target: x86_64-pc-windows-msvc
+  # Beta 32-bit MSVC
+    - channel: beta
+      target: i686-pc-windows-msvc
+  # Nightly 64-bit MSVC
+    - channel: nightly
+      target: x86_64-pc-windows-msvc      
+  # Nightly 32-bit MSVC
+    - channel: nightly
+      target: i686-pc-windows-msvc      
+
+### GNU Toolchains ###
+
+  # Stable 64-bit GNU
+    - channel: stable
+      target: x86_64-pc-windows-gnu
+  # Stable 32-bit GNU
+    - channel: stable
+      target: i686-pc-windows-gnu
+  # Beta 64-bit GNU
+    - channel: beta
+      target: x86_64-pc-windows-gnu
+  # Beta 32-bit GNU
+    - channel: beta
+      target: i686-pc-windows-gnu
+  # Nightly 64-bit GNU
+    - channel: nightly
+      target: x86_64-pc-windows-gnu      
+  # Nightly 32-bit GNU
+    - channel: nightly
+      target: i686-pc-windows-gnu      
+
+### Allowed failures ###
+
+# See Appveyor documentation for specific details. In short, place any channel or targets you wish
+# to allow build failures on (usually nightly at least is a wise choice). This will prevent a build
+# or test failure in the matching channels/targets from failing the entire build.
+matrix:
+  allow_failures:
+    - channel: nightly
+
+# If you only care about stable channel build failures, uncomment the following line:
+    #- channel: beta
+
+## Install Script ##
+
+# This is the most important part of the Appveyor configuration. This installs the version of Rust
+# specified by the 'channel' and 'target' environment variables from the build matrix. This uses
+# rustup to install Rust.
+#
+# For simple configurations, instead of using the build matrix, you can simply set the
+# default-toolchain and default-host manually here.
+install:
+  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init -yv --default-toolchain %channel% --default-host %target%
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - rustc -vV
+  - cargo -vV
+
+## Build Script ##
+
+# 'cargo test' takes care of building for us, so disable Appveyor's build stage. This prevents
+# the "directory does not contain a project or solution file" error.
+build: false
+
+# Uses 'cargo test' to run tests and build. Alternatively, the project may call compiled programs
+#directly or perform other testing commands. Rust will automatically be placed in the PATH
+# environment variable.
+test_script:
+  - cargo test --test lib
+  - cargo test --test lib --release
+  - cargo build --example basic
+  - cargo build --example basic --release 
+  - cargo build --example actix --features actix
+  - cargo build --example actix --features actix --release

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,16 @@ fn generate_assets(ident: &syn::Ident, folder_path: String) -> quote::Tokens {
     .filter(|e| e.file_type().is_file())
   {
     let base = &folder_path.clone();
-    let key = String::from(entry.path().strip_prefix(base).unwrap().to_str().expect("Path does not have a string representation"));
+    let key = String::from(
+      entry
+        .path()
+        .strip_prefix(base)
+        .unwrap()
+        .to_str()
+        .expect("Path does not have a string representation"),
+    );
     let canonical_path = std::fs::canonicalize(entry.path()).expect("Could not get canonical path");
+    let key = if std::path::MAIN_SEPARATOR == '\\' { key.replace('\\', "/") } else { key };
     let canonical_path_str = canonical_path.to_str();
     let value = quote!{
       #key => Some(include_bytes!(#canonical_path_str).to_vec()),


### PR DESCRIPTION
Fix for issue #36
Initially I added all combinations to the appveyor build, but it takes too long. For the last one I reduced it to stabe and 64-bits. You can see it here: https://ci.appveyor.com/project/vemoo/rust-embed/build/1.0.5

You may have to create an account on AppVeyor to link it to this repo.