### PR TITLE
enforce cargo fmt

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -107,6 +107,8 @@ install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %channel% --default-host %target%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - rustup install nightly
+  - rustup component add rustfmt-preview --toolchain nightly
   - if defined MSYS_BITS set PATH=C:\msys64\mingw%MSYS_BITS%\bin;C:\msys64\usr\bin;%PATH%
   - rustc -vV
   - cargo -vV
@@ -121,6 +123,7 @@ build: false
 #directly or perform other testing commands. Rust will automatically be placed in the PATH
 # environment variable.
 test_script:
+  - cargo +nightly fmt --all -- --check
   - cargo test --test lib
   - cargo test --test lib --release
   - cargo build --example basic

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -5,11 +5,11 @@ extern crate rocket_contrib;
 #[macro_use]
 extern crate rust_embed;
 
-use std::path::PathBuf;
+use rocket::http::{ContentType, Status};
+use rocket::response;
 use std::ffi::OsStr;
 use std::io::Cursor;
-use rocket::response;
-use rocket::http::{ContentType, Status};
+use std::path::PathBuf;
 
 #[derive(RustEmbed)]
 #[folder = "examples/public/"]
@@ -19,32 +19,18 @@ struct Asset;
 fn index<'r>() -> response::Result<'r> {
   Asset::get("index.html").map_or_else(
     || Err(Status::NotFound),
-    |d| {
-      response::Response::build()
-        .header(ContentType::HTML)
-        .sized_body(Cursor::new(d))
-        .ok()
-    },
+    |d| response::Response::build().header(ContentType::HTML).sized_body(Cursor::new(d)).ok(),
   )
 }
 
 #[get("/dist/<file..>")]
 fn dist<'r>(file: PathBuf) -> response::Result<'r> {
   let filename = file.display().to_string();
-  let ext = file
-    .as_path()
-    .extension()
-    .and_then(OsStr::to_str)
-    .expect("Could not get file extension");
+  let ext = file.as_path().extension().and_then(OsStr::to_str).expect("Could not get file extension");
   let content_type = ContentType::from_extension(ext).expect("Could not get file content type");
   Asset::get(&filename.clone()).map_or_else(
     || Err(Status::NotFound),
-    |d| {
-      response::Response::build()
-        .header(content_type)
-        .sized_body(Cursor::new(d))
-        .ok()
-    },
+    |d| response::Response::build().header(content_type).sized_body(Cursor::new(d)).ok(),
   )
 }
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -6,4 +6,4 @@ fn_args_density = "Compressed"
 max_width = 160
 tab_spaces = 2
 indent_style = "Block"
-reorder_imported_names = true
+reorder_imports = true


### PR DESCRIPTION
I noticed there was rutfmt.toml checked in but also some unformatted code. It would be great if `cargo fmt` was enforced via CI.
Unfortunately we have to install rust nightly for the stable build as well to use newer rustfmt features.