### PR TITLE
add debug-embed feature to allow embedding in debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rocket_codegen = { version = "0.3.6", optional = true }
 rocket_contrib = { version = "0.3.6", optional = true }
 
 [features]
+debug-embed = []
 nightly = ["rocket", "rocket_codegen", "rocket_contrib"]
 actix = ["actix-web", "mime_guess"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ use quote::Tokens;
 use std::path::Path;
 use syn::*;
 
-#[cfg(debug_assertions)]
+#[cfg(all(debug_assertions, not(feature = "debug-embed")))]
 fn generate_assets(ident: &syn::Ident, folder_path: String) -> quote::Tokens {
   quote!{
       impl #ident {
@@ -41,7 +41,7 @@ fn generate_assets(ident: &syn::Ident, folder_path: String) -> quote::Tokens {
   }
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(any(not(debug_assertions), feature = "debug-embed"))]
 fn generate_assets(ident: &syn::Ident, folder_path: String) -> quote::Tokens {
   use walkdir::WalkDir;
   let mut values = Vec::<Tokens>::new();


### PR DESCRIPTION
As discussed in #41 this adds the `debug-embed` feature.

I didn't add anything to the readme because the feature is not yet release and it might be confusing.

Closes #41