### PR TITLE
restore original folder resolution but leave path.join

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -15,9 +15,6 @@ mod utils;
 
 #[cfg(all(debug_assertions, not(feature = "debug-embed")))]
 fn generate_assets(ident: &syn::Ident, folder_path: String) -> quote::Tokens {
-  use std::env::current_dir;
-  // resolve relative to current path
-  let folder_path = utils::path_to_str(current_dir().unwrap().join(folder_path));
   quote!{
       impl #ident {
           pub fn get(file_path: &str) -> Option<impl AsRef<[u8]>> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -28,6 +28,6 @@ pub fn get_files(folder_path: String) -> impl Iterator<Item = FileEntry> {
     })
 }
 
-pub fn path_to_str<P: AsRef<std::path::Path>>(p: P) -> String {
+fn path_to_str<P: AsRef<std::path::Path>>(p: P) -> String {
   p.as_ref().to_str().expect("Path does not have a string representation").to_owned()
 }


### PR DESCRIPTION
Undo change in folder path resolution introduced in https://github.com/pyros2097/rust-embed/commit/f7cc15722d0b9d93cfe3ff4481a46f4823ce7e75 but leave `let file_path = Path::new(#folder_path).join(file_path);` to fix #30.