### PR TITLE
return Cow<'static, [u8]>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-embed"
-version = "4.1.0"
+version = "4.2.0"
 description = "Rust Custom Derive Macro which loads files into the rust binary at compile time during release and loads the file from the fs during dev"
 readme = "readme.md"
 documentation = "https://docs.rs/rust-embed"
@@ -12,7 +12,7 @@ authors = ["pyros2097 <pyros2097@gmail.com>"]
 
 [dependencies]
 walkdir = "2.1.4"
-rust-embed-impl = { version = "4.1.0", path = "impl"}
+rust-embed-impl = { version = "4.2.0", path = "impl"}
 
 actix-web = { version = "0.7", optional = true }
 mime_guess = { version = "2.0.0-alpha.6", optional = true }

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Thanks to [Mcat12](https://github.com/Mcat12) for the changelog.
 
+## [4.2.0] - 2018-12-02
+### Changed
+- return `Cow<'static, [u8]>` to preserve static lifetime
+
+## [4.1.0] - 2018-10-24
+### Added
+- `iter()` method to list files
+
+## [4.0.0] - 2018-10-11
+### Changed
+- avoid vector allocation by returning `impl AsRef<[u8]>`
+
 ## [3.0.2] - 2018-09-05
 ### Added
 - appveyor for testing on windows

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-embed-impl"
-version = "4.1.0"
+version = "4.2.0"
 description = "Rust Custom Derive Macro which loads files into the rust binary at compile time during release and loads the file from the fs during dev"
 readme = "readme.md"
 documentation = "https://docs.rs/rust-embed"

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ You can use this to embed your css, js and images into a single executable which
 
 ```toml
 [dependencies]
-rust-embed="4.1.0"
+rust-embed="4.2.0"
 ```
 
 ## Documentation
@@ -36,11 +36,11 @@ The macro will generate the following code:
 
 ```rust
 impl Asset {  
-  pub fn get(file_path: &str) -> Option<impl AsRef<[u8]>> {
+  pub fn get(file_path: &str) -> Option<Cow<'static, [u8]>> {
     ...    
   }
   
-  pub fn iter() -> impl Iterator<Item = impl AsRef<str>> {
+  pub fn iter() -> impl Iterator<Item = Cow<'static, str>> {
     ...
   }
 }
@@ -50,9 +50,9 @@ impl Asset {
 
 Given a relative path from the assets folder returns the bytes if found.
 
-If the feature `debug-embed` is enabled or the binary  compiled in release mode the bytes have been embeded in the binary and a `&'static [u8]` is returned.
+If the feature `debug-embed` is enabled or the binary  compiled in release mode the bytes have been embeded in the binary and a `Cow::Borrowed(&'static [u8])` is returned.
 
-Otherwise the bytes are read from the file system on each call and a `Vec<u8>` is returned.
+Otherwise the bytes are read from the file system on each call and a `Cow::Owned(Vec<u8>)` is returned.
 
 
 ### `iter()`


### PR DESCRIPTION
It's a backwards compatible change because `Cow<'static, [u8]>` implements `AsRef<[u8]>`.

I will create another PR to update the actix example when https://github.com/actix/actix-web/pull/611 is released.

Fixes #26.
