### PR TITLE
RustEmbed trait

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -45,10 +45,10 @@ fn generate_assets(ident: &syn::Ident, folder_path: String) -> quote::Tokens {
           }
       }
       impl rust_embed::RustEmbed for #ident {
-        fn get(&self, file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
+        fn get(file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
           #ident::get(file_path)
         }
-        fn iter(&self) -> rust_embed::Filenames {
+        fn iter() -> rust_embed::Filenames {
           // the return type of iter() is unnamable, so we have to box it
           rust_embed::Filenames::Dynamic(Box::new(#ident::iter()))
         }
@@ -93,10 +93,10 @@ fn generate_assets(ident: &syn::Ident, folder_path: String) -> quote::Tokens {
           }
       }
       impl rust_embed::RustEmbed for #ident {
-        fn get(&self, file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
+        fn get(file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
           #ident::get(file_path)
         }
-        fn iter(&self) -> rust_embed::Filenames {
+        fn iter() -> rust_embed::Filenames {
           rust_embed::Filenames::Embedded(#ident::names())
         }
       }

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -44,6 +44,14 @@ fn generate_assets(ident: &syn::Ident, folder_path: String) -> quote::Tokens {
               get_files(String::from(#folder_path)).map(|e| std::borrow::Cow::from(e.rel_path))
           }
       }
+      impl rust_embed::RustEmbed for #ident {
+        fn get(&self, file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
+          #ident::get(file_path)
+        }
+        fn iter(&self) -> Box<dyn Iterator<Item = std::borrow::Cow<'static, str>>> {
+          Box::new(#ident::iter())
+        }
+      }
   }
 }
 
@@ -79,6 +87,14 @@ fn generate_assets(ident: &syn::Ident, folder_path: String) -> quote::Tokens {
               static items: [&str; #array_len] = [#(#list_values),*];
               items.iter().map(|x| std::borrow::Cow::from(*x))
           }
+      }
+      impl rust_embed::RustEmbed for #ident {
+        fn get(&self, file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
+          #ident::get(file_path)
+        }
+        fn iter(&self) -> Box<dyn Iterator<Item = std::borrow::Cow<'static, str>>> {
+          Box::new(#ident::iter())
+        }
       }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,14 @@ impl Asset {
     ...
   }
 }
+impl RustEmbed for Asset {
+  fn get(&self, file_path: &str) -> Option<Cow<'static, [u8]>> {
+    ...
+  }
+  fn iter(&self) -> impl Iterator<Item = Cow<'static, str>> {
+    ...
+  }
+}
 ```
 
 ### `get(file_path: &str)`

--- a/readme.md
+++ b/readme.md
@@ -45,10 +45,10 @@ impl Asset {
   }
 }
 impl RustEmbed for Asset {
-  fn get(&self, file_path: &str) -> Option<Cow<'static, [u8]>> {
+  fn get(file_path: &str) -> Option<Cow<'static, [u8]>> {
     ...
   }
-  fn iter(&self) -> impl Iterator<Item = Cow<'static, str>> {
+  fn iter() -> impl Iterator<Item = Cow<'static, str>> {
     ...
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,38 @@ pub use rust_embed_impl::*;
 #[doc(hidden)]
 #[cfg(all(debug_assertions, not(feature = "debug-embed")))]
 pub mod utils;
+
+/// A directory of binary assets.
+///
+/// They should be embedded into the executable for release builds,
+/// but can be read from the filesystem for debug builds.
+///
+/// This trait is meant to be derived like so:
+/// ```
+/// #[macro_use]
+/// extern crate rust_embed;
+/// #[derive(RustEmbed)]
+/// #[folder = "examples/public/"]
+/// struct Asset;
+/// ```
+
+pub trait RustEmbed {
+  /// Given a relative path from the assets folder, returns the bytes if found.
+  ///
+  /// If the feature `debug-embed` is enabled or the binary is compiled in
+  /// release mode, the bytes have been embeded in the binary and a
+  /// `Cow::Borrowed(&'static [u8])` is returned.
+  ///
+  /// Otherwise, the bytes are read from the file system on each call and a
+  /// `Cow::Owned(Vec<u8>)` is returned.
+  fn get(&self, file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>>;
+
+  /// Iterates the files in this assets folder.
+  ///
+  /// If the feature `debug-embed` is enabled or the binary is compiled in
+  /// release mode, a static array to the list of relative paths to the files
+  /// is used.
+  ///
+  /// Otherwise, the files are listed from the file system on each call.
+  fn iter(&self) -> Filenames;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub trait RustEmbed {
   ///
   /// Otherwise, the bytes are read from the file system on each call and a
   /// `Cow::Owned(Vec<u8>)` is returned.
-  fn get(&self, file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>>;
+  fn get(file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>>;
 
   /// Iterates the files in this assets folder.
   ///
@@ -42,7 +42,7 @@ pub trait RustEmbed {
   /// is used.
   ///
   /// Otherwise, the files are listed from the file system on each call.
-  fn iter(&self) -> Filenames;
+  fn iter() -> Filenames;
 }
 
 /// An iterator type over filenames.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -34,28 +34,14 @@ fn iter_works() {
 
 #[test]
 fn trait_works_generic() {
-  trait_works_generic_helper(&Asset);
+  trait_works_generic_helper::<Asset>();
 }
-fn trait_works_generic_helper(folder: &impl rust_embed::RustEmbed) {
+fn trait_works_generic_helper<E: rust_embed::RustEmbed>() {
   let mut num_files = 0;
-  for file in folder.iter() {
-    assert!(folder.get(file.as_ref()).is_some());
+  for file in E::iter() {
+    assert!(E::get(file.as_ref()).is_some());
     num_files += 1;
   }
   assert_eq!(num_files, 6);
-  assert!(folder.get("gg.html").is_none(), "gg.html should not exist");
-}
-
-#[test]
-fn trait_works_object() {
-  trait_works_object_helper(&Asset);
-}
-fn trait_works_object_helper(folder: &dyn rust_embed::RustEmbed) {
-  let mut num_files = 0;
-  for file in folder.iter() {
-    assert!(folder.get(file.as_ref()).is_some());
-    num_files += 1;
-  }
-  assert_eq!(num_files, 6);
-  assert!(folder.get("gg.html").is_none(), "gg.html should not exist");
+  assert!(E::get("gg.html").is_none(), "gg.html should not exist");
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -31,3 +31,31 @@ fn iter_works() {
   }
   assert_eq!(num_files, 6);
 }
+
+#[test]
+fn trait_works_generic() {
+  trait_works_generic_helper(&Asset);
+}
+fn trait_works_generic_helper(folder: &impl rust_embed::RustEmbed) {
+  let mut num_files = 0;
+  for file in folder.iter() {
+    assert!(folder.get(file.as_ref()).is_some());
+    num_files += 1;
+  }
+  assert_eq!(num_files, 6);
+  assert!(folder.get("gg.html").is_none(), "gg.html should not exist");
+}
+
+#[test]
+fn trait_works_object() {
+  trait_works_object_helper(&Asset);
+}
+fn trait_works_object_helper(folder: &dyn rust_embed::RustEmbed) {
+  let mut num_files = 0;
+  for file in folder.iter() {
+    assert!(folder.get(file.as_ref()).is_some());
+    num_files += 1;
+  }
+  assert_eq!(num_files, 6);
+  assert!(folder.get("gg.html").is_none(), "gg.html should not exist");
+}


### PR DESCRIPTION
My stab at implementing #48; in addition to the existing `impl{}` block for the struct, the codegen also implements a new `RustEmbed` trait.

The `RustEmbed` trait provides `get()` and `iter()` methods, working pretty much the same way as (and mostly delegating to) their inherent counterparts.

The implementation is object-safe, so you could (for example) stick multiple asset folders into an array.