### PR TITLE
Update rocket example to Rocket 0.4.0 so that it builds again.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,11 @@ rust-embed-impl = { version = "4.3.0", path = "impl"}
 actix-web = { version = "0.7", optional = true }
 mime_guess = { version = "2.0.0-alpha.6", optional = true }
 
-rocket = { version = "0.3.6", optional = true }
-rocket_codegen = { version = "0.3.6", optional = true }
-rocket_contrib = { version = "0.3.6", optional = true }
+rocket = { version = "0.4.0", optional = true }
 
 [features]
 debug-embed = ["rust-embed-impl/debug-embed"]
-nightly = ["rocket", "rocket_codegen", "rocket_contrib"]
+nightly = ["rocket"]
 actix = ["actix-web", "mime_guess"]
 
 [badges]

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -1,7 +1,6 @@
-#![feature(test, plugin, decl_macro)]
-#![plugin(rocket_codegen)]
+#![feature(decl_macro, proc_macro_hygiene)]
+#[macro_use]
 extern crate rocket;
-extern crate rocket_contrib;
 #[macro_use]
 extern crate rust_embed;
 


### PR DESCRIPTION
This should :crossed_fingers: fix #53; since ring 0.11.0 is yanked, rocket 0.3.6 probably isn't ever going to build again.