### PR TITLE
Allow using env vars in folder path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rocket = { version = "0.4.0", optional = true }
 
 [features]
 debug-embed = ["rust-embed-impl/debug-embed"]
+shellexpand = ["rust-embed-impl/shellexpand"]
 nightly = ["rocket"]
 actix = ["actix-web", "mime_guess"]
 

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -17,6 +17,7 @@ proc-macro = true
 syn = "0.11"
 quote = "0.3"
 walkdir = "2.2.7"
+shellexpand = "1.0"
 
 [features]
 debug-embed = []

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 syn = "0.11"
 quote = "0.3"
 walkdir = "2.2.7"
-shellexpand = "1.0"
+shellexpand = { version = "1.0", optional = true }
 
 [features]
 debug-embed = []

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -4,6 +4,7 @@ extern crate proc_macro;
 extern crate quote;
 extern crate syn;
 extern crate walkdir;
+#[cfg(feature = "shellexpand")]
 extern crate shellexpand;
 
 use proc_macro::TokenStream;
@@ -118,6 +119,7 @@ fn impl_rust_embed(ast: &syn::DeriveInput) -> Tokens {
       panic!("#[derive(RustEmbed)] attribute value must be a string literal");
     }
   };
+  #[cfg(feature = "shellexpand")]
   let folder_path = shellexpand::full(&folder_path).unwrap_or_else(|e| panic!("{}", e)).to_string();
   if !Path::new(&folder_path).exists() {
     panic!(

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -3,8 +3,8 @@ extern crate proc_macro;
 #[macro_use]
 extern crate quote;
 extern crate syn;
-
 extern crate walkdir;
+extern crate shellexpand;
 
 use proc_macro::TokenStream;
 use quote::Tokens;
@@ -15,7 +15,7 @@ mod utils;
 
 #[cfg(all(debug_assertions, not(feature = "debug-embed")))]
 fn generate_assets(ident: &syn::Ident, folder_path: String) -> quote::Tokens {
-  quote! {      
+  quote! {
       impl #ident {
           pub fn get(file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
               use std::fs::File;
@@ -66,7 +66,7 @@ fn generate_assets(ident: &syn::Ident, folder_path: String) -> quote::Tokens {
 
   let array_len = list_values.len();
 
-  quote! {      
+  quote! {
       impl #ident {
           pub fn get(file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
               match file_path {
@@ -118,6 +118,7 @@ fn impl_rust_embed(ast: &syn::DeriveInput) -> Tokens {
       panic!("#[derive(RustEmbed)] attribute value must be a string literal");
     }
   };
+  let folder_path = shellexpand::full(&folder_path).unwrap_or_else(|e| panic!("{}", e)).to_string();
   if !Path::new(&folder_path).exists() {
     panic!(
       "#[derive(RustEmbed)] folder '{}' does not exist. cwd: '{}'",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,8 +8,6 @@ pub struct FileEntry {
 
 #[cfg_attr(all(debug_assertions, not(feature = "debug-embed")), allow(unused))]
 pub fn get_files(folder_path: String) -> impl Iterator<Item = FileEntry> {
-  use std;
-  use walkdir;
   walkdir::WalkDir::new(&folder_path)
     .into_iter()
     .filter_map(|e| e.ok())
@@ -29,5 +27,5 @@ pub fn get_files(folder_path: String) -> impl Iterator<Item = FileEntry> {
 }
 
 fn path_to_str<P: AsRef<std::path::Path>>(p: P) -> String {
-  p.as_ref().to_str().expect("Path does not have a string representation").to_owned()
+  p.as_ref().display().to_string()
 }


### PR DESCRIPTION
This fixes https://github.com/pyros2097/rust-embed/issues/58 because it allows writing `#[folder = "$CARGO_MANIFEST_DIR/foo"]`.