### PR TITLE
Env vars in folder path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ script:
   - cargo test --test lib
   - cargo test --test lib --features "debug-embed"
   - cargo test --test lib --release
+  - cargo test --test interpolated_path --features "interpolate-folder-path"
+  - cargo test --test interpolated_path --features "interpolate-folder-path" --release
   - cargo build --example basic
-  - cargo build --example basic --release 
+  - cargo build --example basic --release
   - cargo build --example actix --features actix
   - cargo build --example actix --features actix --release
   - cargo build --example warp --features warp-ex

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,26 +10,6 @@ keywords = ["http", "rocket", "static", "web", "server"]
 categories = ["web-programming::http-server"]
 authors = ["pyros2097 <pyros2097@gmail.com>"]
 
-[[test]]
-name = "lib"
-path = "tests/lib.rs"
-required-features = []
-
-[[test]]
-name = "interpolated_path"
-path = "tests/interpolated_path.rs"
-required-features = ["interpolate-folder-path"]
-
-[[example]]
-name = "rocket"
-path = "examples/rocket.rs"
-required-features = ["rocket"]
-
-[[example]]
-name = "warp"
-path = "examples/warp.rs"
-required-features = ["warp"]
-
 [dependencies]
 walkdir = "2.2.7"
 rust-embed-impl = { version = "4.4.0", path = "impl"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,16 @@ keywords = ["http", "rocket", "static", "web", "server"]
 categories = ["web-programming::http-server"]
 authors = ["pyros2097 <pyros2097@gmail.com>"]
 
+[[test]]
+name = "lib"
+path = "tests/lib.rs"
+required-features = []
+
+[[test]]
+name = "interpolated_path"
+path = "tests/interpolated_path.rs"
+required-features = ["interpolate-folder-path"]
+
 [dependencies]
 walkdir = "2.2.7"
 rust-embed-impl = { version = "4.4.0", path = "impl"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rocket = { version = "0.4.1", optional = true }
 
 [features]
 debug-embed = ["rust-embed-impl/debug-embed"]
+interpolate-folder-path = ["rust-embed-impl/interpolate-folder-path"]
 nightly = ["rocket"]
 actix = ["actix-web", "mime_guess"]
 warp-ex = ["warp", "mime_guess"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,16 @@ name = "interpolated_path"
 path = "tests/interpolated_path.rs"
 required-features = ["interpolate-folder-path"]
 
+[[example]]
+name = "rocket"
+path = "examples/rocket.rs"
+required-features = ["rocket"]
+
+[[example]]
+name = "warp"
+path = "examples/warp.rs"
+required-features = ["warp"]
+
 [dependencies]
 walkdir = "2.2.7"
 rust-embed-impl = { version = "4.4.0", path = "impl"}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -133,6 +133,8 @@ test_script:
   - cargo test --test lib
   - cargo test --test lib --features "debug-embed"
   - cargo test --test lib --release
+  - cargo test --test interpolated_path --features "interpolate-folder-path"
+  - cargo test --test interpolated_path --features "interpolate-folder-path" --release
   - cargo build --example basic
   - cargo build --example basic --release
   - cargo build --example actix --features actix

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -18,5 +18,10 @@ syn = "0.11"
 quote = "0.3"
 walkdir = "2.2.7"
 
+[dependencies.shellexpand]
+version = "1.0"
+optional = true
+
 [features]
 debug-embed = []
+interpolate-folder-path = ["shellexpand"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ pub mod utils;
 /// #[derive(RustEmbed)]
 /// #[folder = "examples/public/"]
 /// struct Asset;
+///
+/// fn main() {}
 /// ```
 
 pub trait RustEmbed {

--- a/tests/interpolated_path.rs
+++ b/tests/interpolated_path.rs
@@ -1,0 +1,47 @@
+#[macro_use]
+extern crate rust_embed;
+
+/// Test doc comment
+#[derive(RustEmbed)]
+#[folder = "$CARGO_MANFEST_ROOT/examples/public/"]
+struct Asset;
+
+#[test]
+fn get_works() {
+  match Asset::get("index.html") {
+    None => assert!(false, "index.html should exist"),
+    _ => assert!(true),
+  }
+  match Asset::get("gg.html") {
+    Some(_) => assert!(false, "gg.html should not exist"),
+    _ => assert!(true),
+  }
+  match Asset::get("images/llama.png") {
+    None => assert!(false, "llama.png should exist"),
+    _ => assert!(true),
+  }
+}
+
+#[test]
+fn iter_works() {
+  let mut num_files = 0;
+  for file in Asset::iter() {
+    assert!(Asset::get(file.as_ref()).is_some());
+    num_files += 1;
+  }
+  assert_eq!(num_files, 6);
+}
+
+#[test]
+fn trait_works_generic() {
+  trait_works_generic_helper::<Asset>();
+}
+fn trait_works_generic_helper<E: rust_embed::RustEmbed>() {
+  let mut num_files = 0;
+  for file in E::iter() {
+    assert!(E::get(file.as_ref()).is_some());
+    num_files += 1;
+  }
+  assert_eq!(num_files, 6);
+  assert!(E::get("gg.html").is_none(), "gg.html should not exist");
+}

--- a/tests/interpolated_path.rs
+++ b/tests/interpolated_path.rs
@@ -3,7 +3,7 @@ extern crate rust_embed;
 
 /// Test doc comment
 #[derive(RustEmbed)]
-#[folder = "$CARGO_MANFEST_ROOT/examples/public/"]
+#[folder = "$CARGO_MANIFEST_DIR/examples/public/"]
 struct Asset;
 
 #[test]


### PR DESCRIPTION
This is a revival of GH-59. Fixes GH-58.

Enable shell expansion of folder path to interpolate env variables available during build time such as `OUT_DIR` and `CARGO_MANIFEST_DIR`.

Doc tests in a workspace are run relative to the crate instead of the workspace, which makes paths normally specified relative to the workspace root fail resolution.

cc @Boscop @Mcat12 @pyros2097 