### PR TITLE
Fix import error due to #71

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -41,8 +41,7 @@ fn generate_assets(ident: &syn::Ident, folder_path: String) -> quote::Tokens {
 
           pub fn iter() -> impl Iterator<Item = std::borrow::Cow<'static, str>> {
               use std::path::Path;
-              extern crate rust_embed_utils;
-              rust_embed_utils::get_files(String::from(#folder_path)).map(|e| std::borrow::Cow::from(e.rel_path))
+              rust_embed::utils::get_files(String::from(#folder_path)).map(|e| std::borrow::Cow::from(e.rel_path))
           }
       }
       impl rust_embed::RustEmbed for #ident {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,10 @@ extern crate walkdir;
 extern crate rust_embed_impl;
 pub use rust_embed_impl::*;
 
+#[doc(hidden)]
+#[cfg(all(debug_assertions, not(feature = "debug-embed")))]
+pub extern crate rust_embed_utils as utils;
+
 /// A directory of binary assets.
 ///
 /// They should be embedded into the executable for release builds,


### PR DESCRIPTION
The utils crate is re-exported from the main crate for use in debug builds.

Debug builds are compiled by the macro to use certain functions from the utils crate. This is different than in release mode, where the macro itself uses the functions and does not require them at runtime. When the debug code tries to import the utils crate, it fails because it is not an explicit dependency in Cargo.toml.

Fixes #74