### PR TITLE
Add optional compression with include_flate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ walkdir = "2.2.7"
 rust-embed-impl = { version = "5.2.0", path = "impl"}
 rust-embed-utils = { version = "5.0.0", path = "utils"}
 
+include-flate = { version = "0.1", optional = true, features = ["stable"] }
 actix-web = { version = "1", optional = true }
 mime_guess = { version = "2", optional = true }
 warp = { version = "0.1", optional = true }
@@ -23,6 +24,7 @@ rocket = { version = "0.4.2", optional = true }
 [features]
 debug-embed = ["rust-embed-impl/debug-embed", "rust-embed-utils/debug-embed"]
 interpolate-folder-path = ["rust-embed-impl/interpolate-folder-path"]
+compression = ["rust-embed-impl/compression", "include-flate"]
 nightly = ["rocket"]
 actix = ["actix-web", "mime_guess"]
 warp-ex = ["warp", "mime_guess"]

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -27,3 +27,4 @@ optional = true
 [features]
 debug-embed = []
 interpolate-folder-path = ["shellexpand"]
+compression = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,11 @@
 #[cfg(all(debug_assertions, not(feature = "debug-embed")))]
 extern crate walkdir;
 
+#[cfg(feature = "compression")]
+extern crate include_flate;
+#[cfg(feature = "compression")]
+pub use include_flate::flate;
+
 #[allow(unused_imports)]
 #[macro_use]
 extern crate rust_embed_impl;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate walkdir;
 #[cfg(feature = "compression")]
 extern crate include_flate;
 #[cfg(feature = "compression")]
+#[cfg_attr(feature = "compression", doc(hidden))]
 pub use include_flate::flate;
 
 #[allow(unused_imports)]


### PR DESCRIPTION
Uses the [include_flate] crate to compress assets at compile time. Compression is enabled by the `compression` feature, and is only used when embedding assets (not in debug mode unless using `debug-embed`).

Closes #90 

[include_flate]: https://crates.io/crates/include-flate