### PR TITLE
Update readme and examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: rust
-sudo: false
-dist: trusty
 rust:
   - stable
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ rust-embed-impl = { version = "5.3.0", path = "impl"}
 rust-embed-utils = { version = "5.0.0", path = "utils"}
 
 include-flate = { version = "0.1", optional = true, features = ["stable"] }
-actix-web = { version = "2", optional = true }
+actix-web = { version = "2", default-features = false, optional = true }
 actix-rt = { version = "1", optional = true }
 mime_guess = { version = "2", optional = true }
 tokio = { version = "0.2", optional = true, features = ["macros"] }
-warp = { version = "0.2", optional = true }
-rocket = { version = "0.4.2", optional = true }
+warp = { version = "0.2", default-features = false, optional = true }
+rocket = { version = "0.4.2", default-features = false, optional = true }
 
 [features]
 debug-embed = ["rust-embed-impl/debug-embed", "rust-embed-utils/debug-embed"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ rust-embed-impl = { version = "5.3.0", path = "impl"}
 rust-embed-utils = { version = "5.0.0", path = "utils"}
 
 include-flate = { version = "0.1", optional = true, features = ["stable"] }
-actix-web = { version = "1", optional = true }
+actix-web = { version = "2", optional = true }
+actix-rt = { version = "1", optional = true }
 mime_guess = { version = "2", optional = true }
 warp = { version = "0.1", optional = true }
 rocket = { version = "0.4.2", optional = true }
@@ -27,7 +28,7 @@ debug-embed = ["rust-embed-impl/debug-embed", "rust-embed-utils/debug-embed"]
 interpolate-folder-path = ["rust-embed-impl/interpolate-folder-path"]
 compression = ["rust-embed-impl/compression", "include-flate"]
 nightly = ["rocket"]
-actix = ["actix-web", "mime_guess"]
+actix = ["actix-web", "actix-rt", "mime_guess"]
 warp-ex = ["warp", "mime_guess"]
 
 [badges]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 keywords = ["http", "rocket", "static", "web", "server"]
 categories = ["web-programming::http-server"]
 authors = ["pyros2097 <pyros2097@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 walkdir = "2.2.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ include-flate = { version = "0.1", optional = true, features = ["stable"] }
 actix-web = { version = "2", optional = true }
 actix-rt = { version = "1", optional = true }
 mime_guess = { version = "2", optional = true }
-warp = { version = "0.1", optional = true }
+tokio = { version = "0.2", optional = true, features = ["macros"] }
+warp = { version = "0.2", optional = true }
 rocket = { version = "0.4.2", optional = true }
 
 [features]
@@ -29,7 +30,7 @@ interpolate-folder-path = ["rust-embed-impl/interpolate-folder-path"]
 compression = ["rust-embed-impl/compression", "include-flate"]
 nightly = ["rocket"]
 actix = ["actix-web", "actix-rt", "mime_guess"]
-warp-ex = ["warp", "mime_guess"]
+warp-ex = ["warp", "tokio", "mime_guess"]
 
 [badges]
 appveyor = { repository = "pyros2097/rust-embed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,6 @@ travis-ci = { repository = "pyros2097/rust-embed" }
 is-it-maintained-issue-resolution = { repository = "pyros2097/rust-embed" }
 is-it-maintained-open-issues = { repository = "pyros2097/rust-embed" }
 maintenance = { status = "passively-maintained" }
+
+[workspace]
+members = ["impl", "utils"]

--- a/examples/actix.rs
+++ b/examples/actix.rs
@@ -1,11 +1,12 @@
 extern crate actix_web;
-#[macro_use]
-extern crate rust_embed;
 extern crate mime_guess;
+extern crate rust_embed;
 
 use actix_web::body::Body;
 use actix_web::{web, App, HttpRequest, HttpResponse, HttpServer};
 use mime_guess::from_path;
+use rust_embed::RustEmbed;
+
 use std::borrow::Cow;
 
 #[derive(RustEmbed)]

--- a/examples/actix.rs
+++ b/examples/actix.rs
@@ -1,7 +1,3 @@
-extern crate actix_web;
-extern crate mime_guess;
-extern crate rust_embed;
-
 use actix_web::body::Body;
 use actix_web::{web, App, HttpRequest, HttpResponse, HttpServer};
 use mime_guess::from_path;

--- a/examples/actix.rs
+++ b/examples/actix.rs
@@ -31,14 +31,14 @@ fn dist(req: HttpRequest) -> HttpResponse {
   handle_embedded_file(path)
 }
 
-fn main() {
+#[actix_rt::main]
+async fn main() -> std::io::Result<()> {
   HttpServer::new(|| {
     App::new()
       .service(web::resource("/").route(web::get().to(index)))
       .service(web::resource("/dist/{_:.*}").route(web::get().to(dist)))
   })
-  .bind("127.0.0.1:8000")
-  .unwrap()
+  .bind("127.0.0.1:8000")?
   .run()
-  .unwrap();
+  .await
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,3 @@
-extern crate rust_embed;
-
 use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,6 @@
-#[macro_use]
 extern crate rust_embed;
+
+use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]
 #[folder = "examples/public/"]

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -33,8 +33,8 @@ fn dist<'r>(file: PathBuf) -> response::Result<'r> {
         .as_path()
         .extension()
         .and_then(OsStr::to_str)
-        .ok_or(Status::new(400, "Could not get file extension"))?;
-      let content_type = ContentType::from_extension(ext).ok_or(Status::new(400, "Could not get file content type"))?;
+        .ok_or_else(|| Status::new(400, "Could not get file extension"))?;
+      let content_type = ContentType::from_extension(ext).ok_or_else(|| Status::new(400, "Could not get file content type"))?;
       response::Response::build().header(content_type).sized_body(Cursor::new(d)).ok()
     },
   )

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -1,7 +1,6 @@
 #![feature(decl_macro, proc_macro_hygiene)]
 #[macro_use]
 extern crate rocket;
-extern crate rust_embed;
 
 use rocket::http::{ContentType, Status};
 use rocket::response;

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -1,11 +1,12 @@
 #![feature(decl_macro, proc_macro_hygiene)]
 #[macro_use]
 extern crate rocket;
-#[macro_use]
 extern crate rust_embed;
 
 use rocket::http::{ContentType, Status};
 use rocket::response;
+use rust_embed::RustEmbed;
+
 use std::ffi::OsStr;
 use std::io::Cursor;
 use std::path::PathBuf;

--- a/examples/warp.rs
+++ b/examples/warp.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-
 extern crate rust_embed;
 extern crate warp;
 
@@ -27,7 +25,7 @@ fn serve(path: &str) -> Result<impl Reply, Rejection> {
 
   let asset: Option<Cow<'static, [u8]>> = Asset::get(path);
 
-  let file = asset.ok_or_else(|| warp::reject::not_found())?;
+  let file = asset.ok_or_else(warp::reject::not_found)?;
 
   Ok(Response::builder().header("content-type", mime.to_string()).body(file))
 }

--- a/examples/warp.rs
+++ b/examples/warp.rs
@@ -1,11 +1,12 @@
 #![deny(warnings)]
 
-#[macro_use]
 extern crate rust_embed;
 extern crate warp;
 
-use std::borrow::Cow;
+use rust_embed::RustEmbed;
 use warp::{filters::path::Tail, http::Response, Filter, Rejection, Reply};
+
+use std::borrow::Cow;
 
 #[derive(RustEmbed)]
 #[folder = "examples/public/"]

--- a/examples/warp.rs
+++ b/examples/warp.rs
@@ -1,6 +1,3 @@
-extern crate rust_embed;
-extern crate warp;
-
 use rust_embed::RustEmbed;
 use warp::{filters::path::Tail, http::Response, Filter, Rejection, Reply};
 

--- a/examples/warp.rs
+++ b/examples/warp.rs
@@ -1,28 +1,32 @@
 use rust_embed::RustEmbed;
-use warp::{filters::path::Tail, http::Response, Filter, Rejection, Reply};
-
-use std::borrow::Cow;
+use warp::{http::header::HeaderValue, path::Tail, reply::Response, Filter, Rejection, Reply};
 
 #[derive(RustEmbed)]
 #[folder = "examples/public/"]
 struct Asset;
 
-fn main() {
-  let index_hml = warp::get2().and(warp::path::end()).and_then(|| serve("index.html"));
+#[tokio::main]
+async fn main() {
+  let index_html = warp::path::end().and_then(serve_index);
+  let dist = warp::path!("dist").and(warp::path::tail()).and_then(serve);
 
-  let dist = warp::path("dist").and(warp::path::tail()).and_then(|tail: Tail| serve(tail.as_str()));
-
-  let routes = index_hml.or(dist);
-
-  warp::serve(routes).run(([127, 0, 0, 1], 8080));
+  let routes = index_html.or(dist);
+  warp::serve(routes).run(([127, 0, 0, 1], 8080)).await;
 }
 
-fn serve(path: &str) -> Result<impl Reply, Rejection> {
+async fn serve_index() -> Result<impl Reply, Rejection> {
+  serve_impl("index.html")
+}
+
+async fn serve(path: Tail) -> Result<impl Reply, Rejection> {
+  serve_impl(path.as_str())
+}
+
+fn serve_impl(path: &str) -> Result<impl Reply, Rejection> {
+  let asset = Asset::get(path).ok_or_else(warp::reject::not_found)?;
   let mime = mime_guess::from_path(path).first_or_octet_stream();
 
-  let asset: Option<Cow<'static, [u8]>> = Asset::get(path);
-
-  let file = asset.ok_or_else(warp::reject::not_found)?;
-
-  Ok(Response::builder().header("content-type", mime.to_string()).body(file))
+  let mut res = Response::new(asset.into());
+  res.headers_mut().insert("content-type", HeaderValue::from_str(mime.as_ref()).unwrap());
+  Ok(res)
 }

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -22,7 +22,7 @@ quote = "1"
 walkdir = "2.2.7"
 
 [dependencies.shellexpand]
-version = "1.0"
+version = "2"
 optional = true
 
 [features]

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 keywords = ["http", "rocket", "static", "web", "server"]
 categories = ["web-programming::http-server"]
 authors = ["pyros2097 <pyros2097@gmail.com>"]
+edition = "2018"
 
 [lib]
 proc-macro = true

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -1,12 +1,7 @@
 #![recursion_limit = "1024"]
-extern crate proc_macro;
 #[macro_use]
 extern crate quote;
-extern crate syn;
-
-#[cfg(feature = "interpolate-folder-path")]
-extern crate shellexpand;
-extern crate walkdir;
+extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use std::path::Path;

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -158,7 +158,7 @@ fn impl_rust_embed(ast: &syn::DeriveInput) -> TokenStream2 {
 
     // Add a message about the interpolate-folder-path feature if the path may
     // include a variable
-    if folder_path.contains("$") && cfg!(not(feature = "interpolate-folder-path")) {
+    if folder_path.contains('$') && cfg!(not(feature = "interpolate-folder-path")) {
       message += "\nA variable has been detected. RustEmbed can expand variables \
                   when the `interpolate-folder-path` feature is enabled.";
     }

--- a/readme.md
+++ b/readme.md
@@ -97,8 +97,7 @@ Compress each file when embedding into the binary. Compression is done via [`inc
 ## Usage
 
 ```rust
-#[macro_use]
-extern crate rust_embed;
+use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]
 #[folder = "examples/public/"]

--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,10 @@ Note: To run the `rocket` example, add the `nightly` feature flag and run on a n
 
 `cargo +nightly run --example rocket --features nightly`
 
+Note: To run the `warp` example:
+
+`cargo run --example warp --features warp-ex`
+
 ## Testing
 
 debug: `cargo test --test lib`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@ pub extern crate rust_embed_utils as utils;
 ///
 /// This trait is meant to be derived like so:
 /// ```
-/// #[macro_use]
-/// extern crate rust_embed;
+/// use rust_embed::RustEmbed;
+///
 /// #[derive(RustEmbed)]
 /// #[folder = "examples/public/"]
 /// struct Asset;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,3 @@
-#[cfg(all(debug_assertions, not(feature = "debug-embed")))]
-extern crate walkdir;
-
-#[cfg(feature = "compression")]
-extern crate include_flate;
 #[cfg(feature = "compression")]
 #[cfg_attr(feature = "compression", doc(hidden))]
 pub use include_flate::flate;

--- a/tests/interpolated_path.rs
+++ b/tests/interpolated_path.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate rust_embed;
+use rust_embed::RustEmbed;
 
 /// Test doc comment
 #[derive(RustEmbed)]

--- a/tests/interpolated_path.rs
+++ b/tests/interpolated_path.rs
@@ -7,17 +7,14 @@ struct Asset;
 
 #[test]
 fn get_works() {
-  match Asset::get("index.html") {
-    None => assert!(false, "index.html should exist"),
-    _ => assert!(true),
+  if Asset::get("index.html").is_none() {
+    panic!("index.html should exist");
   }
-  match Asset::get("gg.html") {
-    Some(_) => assert!(false, "gg.html should not exist"),
-    _ => assert!(true),
+  if Asset::get("gg.html").is_some() {
+    panic!("gg.html should not exist");
   }
-  match Asset::get("images/llama.png") {
-    None => assert!(false, "llama.png should exist"),
-    _ => assert!(true),
+  if Asset::get("images/llama.png").is_none() {
+    panic!("llama.png should exist");
   }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate rust_embed;
+use rust_embed::RustEmbed;
 
 /// Test doc comment
 #[derive(RustEmbed)]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -7,17 +7,14 @@ struct Asset;
 
 #[test]
 fn get_works() {
-  match Asset::get("index.html") {
-    None => assert!(false, "index.html should exist"),
-    _ => assert!(true),
+  if Asset::get("index.html").is_none() {
+    panic!("index.html should exist");
   }
-  match Asset::get("gg.html") {
-    Some(_) => assert!(false, "gg.html should not exist"),
-    _ => assert!(true),
+  if Asset::get("gg.html").is_some() {
+    panic!("gg.html should not exist");
   }
-  match Asset::get("images/llama.png") {
-    None => assert!(false, "llama.png should exist"),
-    _ => assert!(true),
+  if Asset::get("images/llama.png").is_none() {
+    panic!("llama.png should exist");
   }
 }
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 keywords = ["http", "rocket", "static", "web", "server"]
 categories = ["web-programming::http-server"]
 authors = ["pyros2097 <pyros2097@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 walkdir = "2.2.7"

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,6 +1,3 @@
-#[cfg(all(debug_assertions, not(feature = "debug-embed")))]
-extern crate walkdir;
-
 #[cfg_attr(all(debug_assertions, not(feature = "debug-embed")), allow(unused))]
 pub struct FileEntry {
   pub rel_path: String,


### PR DESCRIPTION
1. Adds instructions for running the warp example
2. Replaces the use of:

```rust
#[macro_use]
extern crate rust_embed;
```

with:

```rust
use rust_embed::RustEmbed;
```

in examples

3. Updates everything to Rust 2018 edition (the minimum supported version was already 1.31 because of `syn`, Rust 2015 projects will still be able to use rust-embed)
4. Updates the actix-web and the warp examples to the latest version of the crates
5. Updates the travis configuration to use the default settings for the Rust build environment
6. Updates shellexpand to 2.0 [changelog](https://github.com/netvl/shellexpand/tree/6a538c6601ff8e2300f9dcaad39cd87ff12cc51f#version-200)