### PR TITLE
Fix clippy::verbose_file_reads warning in nightly

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -12,20 +12,12 @@ fn generate_assets(ident: &syn::Ident, folder_path: String) -> TokenStream2 {
   quote! {
       impl #ident {
           pub fn get(file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
-              use std::fs::File;
-              use std::io::Read;
+              use std::fs;
               use std::path::Path;
 
               let file_path = Path::new(#folder_path).join(file_path);
-              let mut file = match File::open(file_path) {
-                  Ok(mut file) => file,
-                  Err(_e) => {
-                      return None
-                  }
-              };
-              let mut data: Vec<u8> = Vec::new();
-              match file.read_to_end(&mut data) {
-                  Ok(_) => Some(std::borrow::Cow::from(data)),
+              match fs::read(file_path) {
+                  Ok(contents) => Some(std::borrow::Cow::from(contents)),
                   Err(_e) =>  {
                       return None
                   }


### PR DESCRIPTION
In the latest nightly version, when running

```
$ cargo +nightly clippy -- -D warnings
```

the following warning appears:

![image](https://user-images.githubusercontent.com/51116651/77061260-3dde7e80-69da-11ea-8ddc-ce4a9e1677b7.png)

The related clippy warning is the following: https://rust-lang.github.io/rust-clippy/master/index.html#verbose_file_reads

This PR changes the code that triggers this warning.