### PR TITLE
Use Path when possible to avoid dealing with platform-specifics

### DIFF
--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -24,12 +24,10 @@ fn index<'r>() -> response::Result<'r> {
 
 #[get("/dist/<file..>")]
 fn dist<'r>(file: PathBuf) -> response::Result<'r> {
-  let filename = file.display().to_string();
-  Asset::get(&filename).map_or_else(
+  Asset::get(&file).map_or_else(
     || Err(Status::NotFound),
     |d| {
       let ext = file
-        .as_path()
         .extension()
         .and_then(OsStr::to_str)
         .ok_or_else(|| Status::new(400, "Could not get file extension"))?;

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -9,7 +9,7 @@ use syn::{export::TokenStream2, Data, DeriveInput, Fields, Lit, Meta};
 
 #[allow(unused)]
 fn path_to_str<P: AsRef<Path>>(p: P) -> String {
-  p.as_ref().to_str().expect("Path does not have a string representation").replace("\\", "/")
+  p.as_ref().to_str().expect("Path does not have a string representation").to_owned()
 }
 
 #[cfg(all(debug_assertions, not(feature = "debug-embed")))]
@@ -77,7 +77,7 @@ fn generate_assets(ident: &syn::Ident, folder_path: String) -> TokenStream2 {
   let mut list_values = Vec::<String>::new();
 
   for rust_embed_utils::FileEntry { rel_path, full_canonical_path } in rust_embed_utils::get_files(folder_path) {
-    let rel_path = path_to_str(rel_path);
+    let rel_path = path_to_str(rel_path).replace("\\", "/");
     let full_canonical_path = path_to_str(full_canonical_path);
 
     match_values.push(embed_file(&rel_path, &full_canonical_path));

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -9,7 +9,7 @@ use syn::{export::TokenStream2, Data, DeriveInput, Fields, Lit, Meta};
 
 #[allow(unused)]
 fn path_to_str<P: AsRef<Path>>(p: P) -> String {
-  p.as_ref().to_str().expect("Path does not have a string representation").to_owned()
+  p.as_ref().to_str().expect("Path does not have a string representation").replace("\\", "/")
 }
 
 #[cfg(all(debug_assertions, not(feature = "debug-embed")))]
@@ -89,9 +89,9 @@ fn generate_assets(ident: &syn::Ident, folder_path: String) -> TokenStream2 {
   quote! {
       impl #ident {
           fn __rustembed_get(file_path: &std::path::Path) -> Option<std::borrow::Cow<'static, [u8]>> {
-              let file_path = file_path.to_str()?;
+              let file_path = file_path.to_str()?.replace("\\", "/");
 
-              match file_path {
+              match file_path.as_str() {
                   #(#match_values)*
                   _ => None,
               }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -18,6 +18,15 @@ fn get_works() {
   }
 }
 
+/// Using Windows-style path separators (`\`) is acceptable
+#[test]
+fn get_windows_style() {
+  assert!(
+    Asset::get("images\\llama.png").is_some(),
+    "llama.png should be accessible via \"images\\lama.png\""
+  );
+}
+
 #[test]
 fn iter_works() {
   let mut num_files = 0;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,7 +1,9 @@
+use std::path::PathBuf;
+
 #[cfg_attr(all(debug_assertions, not(feature = "debug-embed")), allow(unused))]
 pub struct FileEntry {
-  pub rel_path: String,
-  pub full_canonical_path: String,
+  pub rel_path: PathBuf,
+  pub full_canonical_path: PathBuf,
 }
 
 #[cfg_attr(all(debug_assertions, not(feature = "debug-embed")), allow(unused))]
@@ -11,19 +13,9 @@ pub fn get_files(folder_path: String) -> impl Iterator<Item = FileEntry> {
     .filter_map(|e| e.ok())
     .filter(|e| e.file_type().is_file())
     .map(move |e| {
-      let rel_path = path_to_str(e.path().strip_prefix(&folder_path).unwrap());
-      let full_canonical_path = path_to_str(std::fs::canonicalize(e.path()).expect("Could not get canonical path"));
-
-      let rel_path = if std::path::MAIN_SEPARATOR == '\\' {
-        rel_path.replace('\\', "/")
-      } else {
-        rel_path
-      };
+      let rel_path = e.path().strip_prefix(&folder_path).unwrap().to_owned();
+      let full_canonical_path = std::fs::canonicalize(e.path()).expect("Could not get canonical path");
 
       FileEntry { rel_path, full_canonical_path }
     })
-}
-
-fn path_to_str<P: AsRef<std::path::Path>>(p: P) -> String {
-  p.as_ref().to_str().expect("Path does not have a string representation").to_owned()
 }


### PR DESCRIPTION
Should fix #115 

Breaking changes:
- `RustEmbed::get` is generic over the input, which needs to impl `AsRef<Path>`
- The standalone `get` and `iter` methods are no longer implemented directly on the struct.
- `Filenames` now is an iterator over `Cow<'static, Path>`