### PR TITLE
Allow Windows-style path separator `\` in `RustEmbed::get`

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -15,7 +15,7 @@ fn generate_assets(ident: &syn::Ident, folder_path: String) -> TokenStream2 {
               use std::fs;
               use std::path::Path;
 
-              let file_path = Path::new(#folder_path).join(file_path);
+              let file_path = Path::new(#folder_path).join(file_path.replace("\\", "/"));
               match fs::read(file_path) {
                   Ok(contents) => Some(std::borrow::Cow::from(contents)),
                   Err(_e) =>  {
@@ -80,7 +80,7 @@ fn generate_assets(ident: &syn::Ident, folder_path: String) -> TokenStream2 {
   quote! {
       impl #ident {
           pub fn get(file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
-              match file_path {
+              match file_path.replace("\\", "/").as_str() {
                   #(#match_values)*
                   _ => None,
               }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -18,6 +18,15 @@ fn get_works() {
   }
 }
 
+/// Using Windows-style path separators (`\`) is acceptable
+#[test]
+fn get_windows_style() {
+  assert!(
+    Asset::get("images\\llama.png").is_some(),
+    "llama.png should be accessible via \"images\\lama.png\""
+  );
+}
+
 #[test]
 fn iter_works() {
   let mut num_files = 0;


### PR DESCRIPTION
Fixes #115 
Replaces #116 

It turns out that we can't utilize `Path` to overcome platform-specific separator issues.
- When embedding the file paths we need to convert to UTF-8 `str`, so we don't benefit from `Path`'s `OsStr` qualities.
- Windows recognizes `/` as a path separator but Unix does not recognize `\` as a path separator, so we can't `Path::join` a Windows-style path to a Unix-style path on a Unix platform. This causes problems with the debug code which loads files from the file system during runtime.
- To find the right file, we match against the file path. `Path` can't be matched upon, so we match upon `&str`. This means the input path and embedded paths must have the same separator, so we don't benefit from `Path`'s separator-agnostic qualities.

Simply increasing the normalization from `\` to `/` solves these problems and doesn't require breaking changes.