### PR TITLE
This isn't an http server implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/rust-embed"
 repository = "https://github.com/pyros2097/rust-embed"
 license = "MIT"
 keywords = ["http", "rocket", "static", "web", "server"]
-categories = ["web-programming::http-server"]
+categories = ["web-programming"]
 authors = ["pyros2097 <pyros2097@gmail.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/rust-embed"
 repository = "https://github.com/pyros2097/rust-embed"
 license = "MIT"
 keywords = ["http", "rocket", "static", "web", "server"]
-categories = ["web-programming"]
+categories = ["web-programming", "filesystem"]
 authors = ["pyros2097 <pyros2097@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
(unless I've massively misunderstood this crate) so it shouldn't be under the **web-programming::http-server** slug. According to https://crates.io/category_slugs,

<dl>
<dt>web-programming</dt>
<dd>Crates to create applications for the web.</dd>
<dt>web-programming::http-server</dt>
<dd>Crates to serve data over HTTP.</dd>
</dl>

This fits much better into the latter, wider category.