### PR TITLE
Follow symlinks and defer debug_assertion evaluation

### DIFF
--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -98,7 +98,7 @@ fn dynamic(ident: &syn::Ident, folder_path: String) -> TokenStream2 {
 
 fn generate_assets(ident: &syn::Ident, folder_path: String) -> TokenStream2 {
   let embedded_impl = embedded(ident, folder_path.clone());
-  if cfg!(feature = "rust-embed") {
+  if cfg!(feature = "debug-embed") {
     return embedded_impl;
   }
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -7,6 +7,7 @@ pub struct FileEntry {
 #[cfg_attr(all(debug_assertions, not(feature = "debug-embed")), allow(unused))]
 pub fn get_files(folder_path: String) -> impl Iterator<Item = FileEntry> {
   walkdir::WalkDir::new(&folder_path)
+    .follow_links(true)
     .into_iter()
     .filter_map(|e| e.ok())
     .filter(|e| e.file_type().is_file())


### PR DESCRIPTION
The large change is refactoring so that rust-embed no longer assumes that it's own compilation flags match those of the expanded code. For example, the proc macro may be compiled in release mode while expanding into code that is compiled in debug mode, or vice versa. This change results in dynamic file lookups when user code is compiled in debug mode, and embedding when compiled in release mode, rather than depending on the compilation of the rust embed proc-macro itself.

The other change included in this PR is to follow symlinks.

Both of these changes are motivated by an attempt to be compatible with the bazel build tool which does not guarantee proc-macro compilation flags match user code compilation flags, and uses symlinks to form a compilation sandbox.