### PR TITLE
Pin syn to version 1.0.57 as temporary fix

### DIFF
--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 [dependencies]
 rust-embed-utils = { version = "5.0.0", path = "../utils"}
 
-syn = "1"
+syn = "=1.0.57"
 quote = "1"
 walkdir = "2.3.1"
 


### PR DESCRIPTION
Commit https://github.com/dtolnay/syn/commit/957840eba2c7f11c95e0227760d78dc481a91de7 to syn clarified what things are private implementation details which has broken access to TokenStream2 used by `rust-embed-impl`. This should be changed in the future but this change should keep it working for now.