### PR TITLE
Fix compiling with latest version of syn

### DIFF
--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -19,6 +19,7 @@ rust-embed-utils = { version = "5.0.0", path = "../utils"}
 
 syn = "1"
 quote = "1"
+proc-macro2 = "1"
 walkdir = "2.3.1"
 
 [dependencies.shellexpand]

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -4,8 +4,9 @@ extern crate quote;
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
 use std::{env, path::Path};
-use syn::{export::TokenStream2, Data, DeriveInput, Fields, Lit, Meta};
+use syn::{Data, DeriveInput, Fields, Lit, Meta};
 
 fn embedded(ident: &syn::Ident, folder_path: String) -> TokenStream2 {
   extern crate rust_embed_utils;


### PR DESCRIPTION
Turns out `syn::export::TokenStream2` was just a re-export of `proc_macro2::TokenStream`, but despite it being `doc(hidden)` RLS must have suggested it to me when I wrote the migration to syn 1.0 in #93.

Fixes #127
Closes #128 