### PR TITLE
add license file to crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ readme = "readme.md"
 documentation = "https://docs.rs/rust-embed"
 repository = "https://github.com/pyros2097/rust-embed"
 license = "MIT"
+license-file = "license"
 keywords = ["http", "rocket", "static", "web", "server"]
 categories = ["web-programming", "filesystem"]
 authors = ["pyros2097 <pyros2097@gmail.com>"]


### PR DESCRIPTION
@AzureMarker Here the mentioned PR to close #135. Adding the existing license file to the published crate to ease automatic license file extraction. This is useful for packages depending on your crate.