### PR TITLE
Remove the license-file Cargo.toml setting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ readme = "readme.md"
 documentation = "https://docs.rs/rust-embed"
 repository = "https://github.com/pyros2097/rust-embed"
 license = "MIT"
-license-file = "license"
 keywords = ["http", "rocket", "static", "web", "server"]
 categories = ["web-programming", "filesystem"]
 authors = ["pyros2097 <pyros2097@gmail.com>"]


### PR DESCRIPTION
According to cargo, only "license" or "license-file" are necessary, not both. "license-file" should only be used with non-standard licenses.

Closes #135 