### PR TITLE
Embed File Metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ path = "tests/interpolated_path.rs"
 required-features = ["interpolate-folder-path"]
 
 [dependencies]
+sha2 = "0.9"
 walkdir = "2.3.1"
 rust-embed-impl = { version = "5.9.0", path = "impl"}
 rust-embed-utils = { version = "5.1.0", path = "utils"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ path = "tests/interpolated_path.rs"
 required-features = ["interpolate-folder-path"]
 
 [dependencies]
-sha2 = "0.9"
 walkdir = "2.3.1"
 rust-embed-impl = { version = "5.9.0", path = "impl"}
 rust-embed-utils = { version = "5.1.0", path = "utils"}
@@ -43,6 +42,9 @@ mime_guess = { version = "2", optional = true }
 tokio = { version = "0.2", optional = true, features = ["macros"] }
 warp = { version = "0.2", default-features = false, optional = true }
 rocket = { version = "0.4.5", default-features = false, optional = true }
+
+[dev-dependencies]
+sha2 = "0.9"
 
 [features]
 debug-embed = ["rust-embed-impl/debug-embed", "rust-embed-utils/debug-embed"]

--- a/examples/actix.rs
+++ b/examples/actix.rs
@@ -12,7 +12,7 @@ struct Asset;
 fn handle_embedded_file(path: &str) -> HttpResponse {
   match Asset::get(path) {
     Some(content) => {
-      let body: Body = match content {
+      let body: Body = match content.data {
         Cow::Borrowed(bytes) => bytes.into(),
         Cow::Owned(bytes) => bytes.into(),
       };

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -6,5 +6,5 @@ struct Asset;
 
 fn main() {
   let index_html = Asset::get("index.html").unwrap();
-  println!("{:?}", std::str::from_utf8(index_html.as_ref()));
+  println!("{:?}", std::str::from_utf8(index_html.data.as_ref()));
 }

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -18,7 +18,7 @@ struct Asset;
 fn index<'r>() -> response::Result<'r> {
   Asset::get("index.html").map_or_else(
     || Err(Status::NotFound),
-    |d| response::Response::build().header(ContentType::HTML).sized_body(Cursor::new(d)).ok(),
+    |d| response::Response::build().header(ContentType::HTML).sized_body(Cursor::new(d.data)).ok(),
   )
 }
 

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -34,7 +34,7 @@ fn dist<'r>(file: PathBuf) -> response::Result<'r> {
         .and_then(OsStr::to_str)
         .ok_or_else(|| Status::new(400, "Could not get file extension"))?;
       let content_type = ContentType::from_extension(ext).ok_or_else(|| Status::new(400, "Could not get file content type"))?;
-      response::Response::build().header(content_type).sized_body(Cursor::new(d)).ok()
+      response::Response::build().header(content_type).sized_body(Cursor::new(d.data)).ok()
     },
   )
 }

--- a/examples/warp.rs
+++ b/examples/warp.rs
@@ -26,7 +26,7 @@ fn serve_impl(path: &str) -> Result<impl Reply, Rejection> {
   let asset = Asset::get(path).ok_or_else(warp::reject::not_found)?;
   let mime = mime_guess::from_path(path).first_or_octet_stream();
 
-  let mut res = Response::new(asset.into());
+  let mut res = Response::new(asset.data.into());
   res.headers_mut().insert("content-type", HeaderValue::from_str(mime.as_ref()).unwrap());
   Ok(res)
 }

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -140,12 +140,12 @@ fn embed_file(rel_path: &str, full_canonical_path: &str) -> TokenStream2 {
 
   let embedding_code = if cfg!(feature = "compression") {
     quote! {
-        let bytes = &include_bytes!(#full_canonical_path)[..];
+      rust_embed::flate!(static FILE: [u8] from #full_canonical_path);
+      let bytes = &FILE[..];
     }
   } else {
     quote! {
-        rust_embed::flate!(static FILE: [u8] from #full_canonical_path);
-        let bytes = &FILE[..];
+      let bytes = &include_bytes!(#full_canonical_path)[..];
     }
   };
 

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -46,7 +46,7 @@ fn embedded(ident: &syn::Ident, folder_path: String, prefix: Option<&str>) -> To
   quote! {
       #not_debug_attr
       impl #ident {
-          pub fn get(file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
+          pub fn get(file_path: &str) -> Option<rust_embed::EmbeddedFile> {
             #handle_prefix
             match file_path.replace("\\", "/").as_str() {
                 #(#match_values)*
@@ -66,7 +66,7 @@ fn embedded(ident: &syn::Ident, folder_path: String, prefix: Option<&str>) -> To
 
       #not_debug_attr
       impl rust_embed::RustEmbed for #ident {
-        fn get(file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
+        fn get(file_path: &str) -> Option<rust_embed::EmbeddedFile> {
           #ident::get(file_path)
         }
         fn iter() -> rust_embed::Filenames {
@@ -89,19 +89,11 @@ fn dynamic(ident: &syn::Ident, folder_path: String, prefix: Option<&str>) -> Tok
   quote! {
       #[cfg(debug_assertions)]
       impl #ident {
-          pub fn get(file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
-              use std::fs;
-              use std::path::Path;
-
+          pub fn get(file_path: &str) -> Option<rust_embed::EmbeddedFile> {
               #handle_prefix
 
-              let file_path = Path::new(#folder_path).join(file_path.replace("\\", "/"));
-              match fs::read(file_path) {
-                  Ok(contents) => Some(std::borrow::Cow::from(contents)),
-                  Err(_e) =>  {
-                      return None
-                  }
-              }
+              let file_path = std::path::Path::new(#folder_path).join(file_path.replace("\\", "/"));
+              rust_embed::utils::read_file_from_fs(&file_path).ok()
           }
 
           pub fn iter() -> impl Iterator<Item = std::borrow::Cow<'static, str>> {
@@ -113,7 +105,7 @@ fn dynamic(ident: &syn::Ident, folder_path: String, prefix: Option<&str>) -> Tok
 
       #[cfg(debug_assertions)]
       impl rust_embed::RustEmbed for #ident {
-        fn get(file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
+        fn get(file_path: &str) -> Option<rust_embed::EmbeddedFile> {
           #ident::get(file_path)
         }
         fn iter() -> rust_embed::Filenames {
@@ -138,25 +130,34 @@ fn generate_assets(ident: &syn::Ident, folder_path: String, prefix: Option<Strin
   }
 }
 
-#[cfg(not(feature = "compression"))]
 fn embed_file(rel_path: &str, full_canonical_path: &str) -> TokenStream2 {
-  quote! {
-    #rel_path => {
+  let file = rust_embed_utils::read_file_from_fs(Path::new(full_canonical_path)).expect("File should be readable");
+  let hash = file.metadata.sha256_hash();
+  let last_modified = match file.metadata.last_modified() {
+    Some(last_modified) => quote! { Some(#last_modified) },
+    None => quote! { None },
+  };
+
+  let embedding_code = if cfg!(feature = "compression") {
+    quote! {
         let bytes = &include_bytes!(#full_canonical_path)[..];
-        Some(std::borrow::Cow::from(bytes))
-    },
-  }
-}
-
-#[cfg(feature = "compression")]
-fn embed_file(rel_path: &str, full_canonical_path: &str) -> TokenStream2 {
-  quote! {
-    #rel_path => {
+    }
+  } else {
+    quote! {
         rust_embed::flate!(static FILE: [u8] from #full_canonical_path);
-
         let bytes = &FILE[..];
-        Some(std::borrow::Cow::from(bytes))
-    },
+    }
+  };
+
+  quote! {
+      #rel_path => {
+          #embedding_code
+
+          Some(rust_embed::EmbeddedFile {
+              data: std::borrow::Cow::from(bytes),
+              metadata: rust_embed::Metadata::__rust_embed_new([#(#hash),*], #last_modified)
+          })
+      }
   }
 }
 
@@ -213,7 +214,7 @@ fn impl_rust_embed(ast: &syn::DeriveInput) -> TokenStream2 {
                   when the `interpolate-folder-path` feature is enabled.";
     }
 
-    panic!(message);
+    panic!("{}", message);
   };
 
   generate_assets(&ast.ident, folder_path, prefix)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,17 @@
 #[cfg_attr(feature = "compression", doc(hidden))]
 pub use include_flate::flate;
 
+#[doc(hidden)]
+pub use sha2;
+
 #[allow(unused_imports)]
 #[macro_use]
 extern crate rust_embed_impl;
 pub use rust_embed_impl::*;
 
+pub use rust_embed_utils::{EmbeddedFile, Metadata};
+
 #[doc(hidden)]
-#[cfg(all(debug_assertions, not(feature = "debug-embed")))]
 pub extern crate rust_embed_utils as utils;
 
 /// A directory of binary assets.
@@ -37,7 +41,7 @@ pub trait RustEmbed {
   ///
   /// Otherwise, the bytes are read from the file system on each call and a
   /// `Cow::Owned(Vec<u8>)` is returned.
-  fn get(file_path: &str) -> Option<std::borrow::Cow<'static, [u8]>>;
+  fn get(file_path: &str) -> Option<EmbeddedFile>;
 
   /// Iterates the files in this assets folder.
   ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,6 @@
 #[cfg_attr(feature = "compression", doc(hidden))]
 pub use include_flate::flate;
 
-#[doc(hidden)]
-pub use sha2;
-
 #[allow(unused_imports)]
 #[macro_use]
 extern crate rust_embed_impl;

--- a/tests/interpolated_path.rs
+++ b/tests/interpolated_path.rs
@@ -7,15 +7,9 @@ struct Asset;
 
 #[test]
 fn get_works() {
-  if Asset::get("index.html").is_none() {
-    panic!("index.html should exist");
-  }
-  if Asset::get("gg.html").is_some() {
-    panic!("gg.html should not exist");
-  }
-  if Asset::get("images/llama.png").is_none() {
-    panic!("llama.png should exist");
-  }
+  assert!(Asset::get("index.html").is_some(), "index.html should exist");
+  assert!(Asset::get("gg.html").is_none(), "gg.html should not exist");
+  assert!(Asset::get("images/llama.png").is_some(), "llama.png should exist");
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -7,15 +7,9 @@ struct Asset;
 
 #[test]
 fn get_works() {
-  if Asset::get("index.html").is_none() {
-    panic!("index.html should exist");
-  }
-  if Asset::get("gg.html").is_some() {
-    panic!("gg.html should not exist");
-  }
-  if Asset::get("images/llama.png").is_none() {
-    panic!("llama.png should exist");
-  }
+  assert!(Asset::get("index.html").is_some(), "index.html should exist");
+  assert!(Asset::get("gg.html").is_none(), "gg.html should not exist");
+  assert!(Asset::get("images/llama.png").is_some(), "llama.png should exist");
 }
 
 /// Using Windows-style path separators (`\`) is acceptable

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -1,0 +1,24 @@
+use rust_embed::{EmbeddedFile, RustEmbed};
+use sha2::Digest;
+
+#[derive(RustEmbed)]
+#[folder = "examples/public/"]
+struct Asset;
+
+#[test]
+fn hash_is_accurate() {
+  let index_file: EmbeddedFile = Asset::get("index.html").expect("index.html exists");
+  let mut hasher = sha2::Sha256::new();
+  hasher.update(index_file.data);
+  let expected_hash: [u8; 32] = hasher.finalize().into();
+
+  assert_eq!(index_file.metadata.sha256_hash(), expected_hash);
+}
+
+#[test]
+fn last_modified_is_accurate() {
+  let index_file: EmbeddedFile = Asset::get("index.html").expect("index.html exists");
+  let expected_datetime_utc = 1527818165;
+
+  assert_eq!(index_file.metadata.last_modified(), Some(expected_datetime_utc));
+}

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 
 [dependencies]
 walkdir = "2.3.1"
+sha2 = "0.9"
 
 [features]
 debug-embed = []

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -33,11 +33,13 @@ pub fn get_files(folder_path: String) -> impl Iterator<Item = FileEntry> {
     })
 }
 
+/// A file embedded into the binary
 pub struct EmbeddedFile {
   pub data: Cow<'static, [u8]>,
   pub metadata: Metadata,
 }
 
+/// Metadata about an embedded file
 pub struct Metadata {
   hash: [u8; 32],
   last_modified: Option<u64>,

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -1,4 +1,11 @@
 #![forbid(unsafe_code)]
+
+use sha2::Digest;
+use std::borrow::Cow;
+use std::path::Path;
+use std::time::SystemTime;
+use std::{fs, io};
+
 #[cfg_attr(all(debug_assertions, not(feature = "debug-embed")), allow(unused))]
 pub struct FileEntry {
   pub rel_path: String,
@@ -24,6 +31,55 @@ pub fn get_files(folder_path: String) -> impl Iterator<Item = FileEntry> {
 
       FileEntry { rel_path, full_canonical_path }
     })
+}
+
+pub struct EmbeddedFile {
+  pub data: Cow<'static, [u8]>,
+  pub metadata: Metadata,
+}
+
+pub struct Metadata {
+  hash: [u8; 32],
+  last_modified: Option<u64>,
+}
+
+impl Metadata {
+  #[doc(hidden)]
+  pub fn __rust_embed_new(hash: [u8; 32], last_modified: Option<u64>) -> Self {
+    Self { hash, last_modified }
+  }
+
+  /// The SHA256 hash of the file
+  pub fn sha256_hash(&self) -> [u8; 32] {
+    self.hash
+  }
+
+  /// The last modified date in seconds since the UNIX epoch. If the underlying
+  /// platform/file-system does not support this, None is returned.
+  pub fn last_modified(&self) -> Option<u64> {
+    self.last_modified
+  }
+}
+
+pub fn read_file_from_fs(file_path: &Path) -> io::Result<EmbeddedFile> {
+  let data = fs::read(file_path)?;
+  let data = Cow::from(data);
+
+  let mut hasher = sha2::Sha256::new();
+  hasher.update(&data);
+  let hash: [u8; 32] = hasher.finalize().into();
+
+  let last_modified = fs::metadata(file_path)?.modified().ok().map(|last_modified| {
+    last_modified
+      .duration_since(SystemTime::UNIX_EPOCH)
+      .expect("Time before the UNIX epoch is unsupported")
+      .as_secs()
+  });
+
+  Ok(EmbeddedFile {
+    data,
+    metadata: Metadata { hash, last_modified },
+  })
 }
 
 fn path_to_str<P: AsRef<std::path::Path>>(p: P) -> String {


### PR DESCRIPTION
Changes the returned data type from a `Cow<'static, [u8]>` to `EmbeddedFile` which contains metadata about the file:
```rust
/// A file embedded into the binary
pub struct EmbeddedFile {
  pub data: Cow<'static, [u8]>,
  pub metadata: Metadata,
}

/// Metadata about an embedded file
pub struct Metadata {
  hash: [u8; 32],
  last_modified: Option<u64>,
}
```

The metadata fields are private to allow for adding more without a major version change. There are methods on `Metadata` which return the hash and last modified data.

Closes #140 