### PR TITLE
implement support for multiple include/exclude glob attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ name = "interpolated_path"
 path = "tests/interpolated_path.rs"
 required-features = ["interpolate-folder-path"]
 
+[[test]]
+name = "include_exclude"
+path = "tests/include_exclude.rs"
+required-features = ["include-exclude"]
+
 [dependencies]
 walkdir = "2.3.1"
 rust-embed-impl = { version = "6.0.1", path = "impl"}
@@ -50,6 +55,7 @@ sha2 = "0.9"
 debug-embed = ["rust-embed-impl/debug-embed", "rust-embed-utils/debug-embed"]
 interpolate-folder-path = ["rust-embed-impl/interpolate-folder-path"]
 compression = ["rust-embed-impl/compression", "include-flate"]
+include-exclude = ["rust-embed-impl/include-exclude"]
 nightly = ["rocket"]
 actix = ["actix-web", "mime_guess"]
 warp-ex = ["warp", "tokio", "mime_guess"]

--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -30,3 +30,4 @@ optional = true
 debug-embed = []
 interpolate-folder-path = ["shellexpand"]
 compression = []
+include-exclude = ["rust-embed-utils/include-exclude"]

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -211,16 +211,11 @@ fn impl_rust_embed(ast: &syn::DeriveInput) -> TokenStream2 {
     _ => panic!("RustEmbed can only be derived for unit structs"),
   };
 
-  let folder_path: String = {
-    let mut it = find_attribute_values(ast, "folder").into_iter();
-
-    match (it.next(), it.next()) {
-      (Some(folder_path), None) => folder_path,
-      _ => {
-        panic!("#[derive(RustEmbed)] must contain one attribute like this #[folder = \"examples/public/\"]");
-      }
-    }
-  };
+  let mut folder_paths = find_attribute_values(ast, "folder");
+  if folder_paths.len() != 1 {
+    panic!("#[derive(RustEmbed)] must contain one attribute like this #[folder = \"examples/public/\"]");
+  }
+  let folder_path = folder_paths.remove(0);
 
   let prefix = find_attribute_values(ast, "prefix").into_iter().next();
   let includes = find_attribute_values(ast, "include");

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -9,13 +9,13 @@ use proc_macro2::TokenStream as TokenStream2;
 use std::{env, path::Path};
 use syn::{Data, DeriveInput, Fields, Lit, Meta, MetaNameValue};
 
-fn embedded(ident: &syn::Ident, folder_path: String, prefix: Option<&str>) -> TokenStream2 {
+fn embedded(ident: &syn::Ident, folder_path: String, prefix: Option<&str>, includes: Vec<String>, excludes: Vec<String>) -> TokenStream2 {
   extern crate rust_embed_utils;
 
   let mut match_values = Vec::<TokenStream2>::new();
   let mut list_values = Vec::<String>::new();
 
-  for rust_embed_utils::FileEntry { rel_path, full_canonical_path } in rust_embed_utils::get_files(folder_path) {
+  for rust_embed_utils::FileEntry { rel_path, full_canonical_path } in rust_embed_utils::get_files(folder_path, includes, excludes) {
     match_values.push(embed_file(&rel_path, &full_canonical_path));
 
     list_values.push(if let Some(prefix) = prefix {
@@ -78,7 +78,7 @@ fn embedded(ident: &syn::Ident, folder_path: String, prefix: Option<&str>) -> To
   }
 }
 
-fn dynamic(ident: &syn::Ident, folder_path: String, prefix: Option<&str>) -> TokenStream2 {
+fn dynamic(ident: &syn::Ident, folder_path: String, prefix: Option<&str>, includes: Vec<String>, excludes: Vec<String>) -> TokenStream2 {
   let (handle_prefix, map_iter) = if let Some(prefix) = prefix {
     (
       quote! { let file_path = file_path.strip_prefix(#prefix)?; },
@@ -86,6 +86,14 @@ fn dynamic(ident: &syn::Ident, folder_path: String, prefix: Option<&str>) -> Tok
     )
   } else {
     (TokenStream2::new(), quote! { std::borrow::Cow::from(e.rel_path) })
+  };
+
+  let includes = quote! {
+    vec![#(String::from(#includes)),*]
+  };
+
+  let excludes = quote! {
+    vec![#(String::from(#excludes)),*]
   };
 
   quote! {
@@ -96,13 +104,21 @@ fn dynamic(ident: &syn::Ident, folder_path: String, prefix: Option<&str>) -> Tok
               #handle_prefix
 
               let file_path = std::path::Path::new(#folder_path).join(file_path.replace("\\", "/"));
-              rust_embed::utils::read_file_from_fs(&file_path).ok()
+              let rel_file_path = file_path.to_str()
+                .expect("Path does not have a string representation")
+                .strip_prefix(#folder_path).expect("Failed to turn path to relative path");
+
+              if rust_embed::utils::is_path_included(rel_file_path, &#includes, &#excludes) {
+                rust_embed::utils::read_file_from_fs(&file_path).ok()
+              } else {
+                None
+              }
           }
 
           /// Iterates over the file paths in the folder.
           pub fn iter() -> impl Iterator<Item = std::borrow::Cow<'static, str>> {
               use std::path::Path;
-              rust_embed::utils::get_files(String::from(#folder_path))
+              rust_embed::utils::get_files(String::from(#folder_path), #includes, #excludes)
                   .map(|e| #map_iter)
           }
       }
@@ -120,13 +136,13 @@ fn dynamic(ident: &syn::Ident, folder_path: String, prefix: Option<&str>) -> Tok
   }
 }
 
-fn generate_assets(ident: &syn::Ident, folder_path: String, prefix: Option<String>) -> TokenStream2 {
-  let embedded_impl = embedded(ident, folder_path.clone(), prefix.as_deref());
+fn generate_assets(ident: &syn::Ident, folder_path: String, prefix: Option<String>, includes: Vec<String>, excludes: Vec<String>) -> TokenStream2 {
+  let embedded_impl = embedded(ident, folder_path.clone(), prefix.as_deref(), includes.clone(), excludes.clone());
   if cfg!(feature = "debug-embed") {
     return embedded_impl;
   }
 
-  let dynamic_impl = dynamic(ident, folder_path, prefix.as_deref());
+  let dynamic_impl = dynamic(ident, folder_path, prefix.as_deref(), includes, excludes);
 
   quote! {
       #embedded_impl
@@ -165,17 +181,23 @@ fn embed_file(rel_path: &str, full_canonical_path: &str) -> TokenStream2 {
   }
 }
 
-/// Find a `name = "value"` attribute from the derive input
-fn find_attribute_value(ast: &syn::DeriveInput, attr_name: &str) -> Option<String> {
+/// Find all pairs of the `name = "value"` attribute from the derive input
+fn find_attribute_values(ast: &syn::DeriveInput, attr_name: &str) -> Vec<String> {
   ast
     .attrs
     .iter()
-    .find(|value| value.path.is_ident(attr_name))
-    .and_then(|attr| attr.parse_meta().ok())
-    .and_then(|meta| match meta {
+    .filter(|value| value.path.is_ident(attr_name))
+    .filter_map(|attr| attr.parse_meta().ok())
+    .filter_map(|meta| match meta {
       Meta::NameValue(MetaNameValue { lit: Lit::Str(val), .. }) => Some(val.value()),
       _ => None,
     })
+    .collect()
+}
+
+/// Find a `name = "value"` attribute from the derive input
+fn find_attribute_value(ast: &syn::DeriveInput, attr_name: &str) -> Option<String> {
+  find_attribute_values(ast, attr_name).into_iter().next()
 }
 
 fn impl_rust_embed(ast: &syn::DeriveInput) -> TokenStream2 {
@@ -189,6 +211,8 @@ fn impl_rust_embed(ast: &syn::DeriveInput) -> TokenStream2 {
 
   let folder_path = find_attribute_value(ast, "folder").expect("#[derive(RustEmbed)] should contain one attribute like this #[folder = \"examples/public/\"]");
   let prefix = find_attribute_value(ast, "prefix");
+  let includes = find_attribute_values(ast, "include");
+  let excludes = find_attribute_values(ast, "exclude");
 
   #[cfg(feature = "interpolate-folder-path")]
   let folder_path = shellexpand::full(&folder_path).unwrap().to_string();
@@ -221,10 +245,10 @@ fn impl_rust_embed(ast: &syn::DeriveInput) -> TokenStream2 {
     panic!("{}", message);
   };
 
-  generate_assets(&ast.ident, folder_path, prefix)
+  generate_assets(&ast.ident, folder_path, prefix, includes, excludes)
 }
 
-#[proc_macro_derive(RustEmbed, attributes(folder, prefix))]
+#[proc_macro_derive(RustEmbed, attributes(folder, prefix, include, exclude))]
 pub fn derive_input_object(input: TokenStream) -> TokenStream {
   let ast: DeriveInput = syn::parse(input).unwrap();
   let gen = impl_rust_embed(&ast);

--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,21 @@ This will pull the `foo` directory relative to your `Cargo.toml` file.
 
 Compress each file when embedding into the binary. Compression is done via [`include-flate`].
 
+### `include-exclude`
+Filter files to be embedded with multiple `#[include = "*.txt"]` and `#[exclude = "*.jpg"]` attributes. 
+Matching is done on relative file paths, via [`glob`].
+`exclude` attributes have higher priority than `include` attributes.
+Example:
+
+```rust
+#[derive(RustEmbed)]
+#[folder = "examples/public/"]
+#[include = "*.html"]
+#[include = "images/*"]
+#[exclude = "*.txt"]
+struct Asset;
+```
+
 ## Usage
 
 ```rust
@@ -154,3 +169,4 @@ Go Rusketeers!
 The power is yours!
 
 [`include-flate`]: https://crates.io/crates/include-flate
+[`glob`]: https://crates.io/crates/glob

--- a/tests/include_exclude.rs
+++ b/tests/include_exclude.rs
@@ -1,0 +1,54 @@
+use rust_embed::RustEmbed;
+
+#[derive(RustEmbed)]
+#[folder = "examples/public/"]
+struct AllAssets;
+
+#[test]
+fn get_works() {
+  assert!(AllAssets::get("index.html").is_some(), "index.html should exist");
+  assert!(AllAssets::get("gg.html").is_none(), "gg.html should not exist");
+  assert!(AllAssets::get("images/llama.png").is_some(), "llama.png should exist");
+  assert_eq!(AllAssets::iter().count(), 6);
+}
+
+#[derive(RustEmbed)]
+#[folder = "examples/public/"]
+#[include = "*.html"]
+#[include = "images/*"]
+struct IncludeSomeAssets;
+
+#[test]
+fn including_some_assets_works() {
+  assert!(IncludeSomeAssets::get("index.html").is_some(), "index.html should exist");
+  assert!(IncludeSomeAssets::get("main.js").is_none(), "main.js should not exist");
+  assert!(IncludeSomeAssets::get("images/llama.png").is_some(), "llama.png should exist");
+  assert_eq!(IncludeSomeAssets::iter().count(), 4);
+}
+
+#[derive(RustEmbed)]
+#[folder = "examples/public/"]
+#[exclude = "*.html"]
+#[exclude = "images/*"]
+struct ExcludeSomeAssets;
+
+#[test]
+fn excluding_some_assets_works() {
+  assert!(ExcludeSomeAssets::get("index.html").is_none(), "index.html should not exist");
+  assert!(ExcludeSomeAssets::get("main.js").is_some(), "main.js should exist");
+  assert!(ExcludeSomeAssets::get("images/llama.png").is_none(), "llama.png should not exist");
+  assert_eq!(ExcludeSomeAssets::iter().count(), 2);
+}
+
+#[derive(RustEmbed)]
+#[folder = "examples/public/"]
+#[include = "images/*"]
+#[exclude = "*.txt"]
+struct ExcludePriorityAssets;
+
+#[test]
+fn exclude_has_higher_priority() {
+  assert!(ExcludePriorityAssets::get("images/doc.txt").is_none(), "doc.txt should not exist");
+  assert!(ExcludePriorityAssets::get("images/llama.png").is_some(), "llama.png should exist");
+  assert_eq!(ExcludePriorityAssets::iter().count(), 2);
+}

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -1,5 +1,6 @@
 use rust_embed::{EmbeddedFile, RustEmbed};
 use sha2::Digest;
+use std::{fs, time::SystemTime};
 
 #[derive(RustEmbed)]
 #[folder = "examples/public/"]
@@ -18,7 +19,9 @@ fn hash_is_accurate() {
 #[test]
 fn last_modified_is_accurate() {
   let index_file: EmbeddedFile = Asset::get("index.html").expect("index.html exists");
-  let expected_datetime_utc = 1527818165;
+
+  let metadata = fs::metadata(format!("{}/examples/public/index.html", env!("CARGO_MANIFEST_DIR"))).unwrap();
+  let expected_datetime_utc = metadata.modified().unwrap().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs();
 
   assert_eq!(index_file.metadata.last_modified(), Some(expected_datetime_utc));
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -15,5 +15,10 @@ edition = "2018"
 walkdir = "2.3.1"
 sha2 = "0.9"
 
+[dependencies.glob]
+version = "0.3.0"
+optional = true
+
 [features]
 debug-embed = []
+include-exclude = ["glob"]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -13,17 +13,17 @@ pub struct FileEntry {
 }
 
 #[cfg(not(feature = "include-exclude"))]
-pub fn is_path_included(_path: &str, _includes: &Vec<String>, _excludes: &Vec<String>) -> bool {
+pub fn is_path_included(_path: &str, _includes: &[&str], _excludes: &[&str]) -> bool {
   return true;
 }
 
 #[cfg(feature = "include-exclude")]
-pub fn is_path_included(rel_path: &str, includes: &Vec<String>, excludes: &Vec<String>) -> bool {
+pub fn is_path_included(rel_path: &str, includes: &[&str], excludes: &[&str]) -> bool {
   use glob::Pattern;
 
   // ignore path matched by exclusion pattern
   for exclude in excludes {
-    let pattern = Pattern::new(exclude).expect(&format!("invalid exclude pattern '{}'", exclude));
+    let pattern = Pattern::new(exclude).unwrap_or_else(|_| panic!("invalid exclude pattern '{}'", exclude));
 
     if pattern.matches(rel_path) {
       return false;
@@ -37,18 +37,18 @@ pub fn is_path_included(rel_path: &str, includes: &Vec<String>, excludes: &Vec<S
 
   // accept path if matched by inclusion pattern
   for include in includes {
-    let pattern = Pattern::new(include).expect(&format!("invalid include pattern '{}'", include));
+    let pattern = Pattern::new(include).unwrap_or_else(|_| panic!("invalid include pattern '{}'", include));
 
     if pattern.matches(rel_path) {
       return true;
     }
   }
 
-  return false;
+  false
 }
 
 #[cfg_attr(all(debug_assertions, not(feature = "debug-embed")), allow(unused))]
-pub fn get_files(folder_path: String, includes: Vec<String>, excludes: Vec<String>) -> impl Iterator<Item = FileEntry> {
+pub fn get_files<'patterns>(folder_path: String, includes: &'patterns [&str], excludes: &'patterns [&str]) -> impl Iterator<Item = FileEntry> + 'patterns {
   walkdir::WalkDir::new(&folder_path)
     .follow_links(true)
     .into_iter()
@@ -64,7 +64,7 @@ pub fn get_files(folder_path: String, includes: Vec<String>, excludes: Vec<Strin
         rel_path
       };
 
-      if is_path_included(&rel_path, &includes, &excludes) {
+      if is_path_included(&rel_path, includes, excludes) {
         Some(FileEntry { rel_path, full_canonical_path })
       } else {
         None

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -14,7 +14,7 @@ pub struct FileEntry {
 
 #[cfg(not(feature = "include-exclude"))]
 pub fn is_path_included(_path: &str, _includes: &[&str], _excludes: &[&str]) -> bool {
-  return true;
+  true
 }
 
 #[cfg(feature = "include-exclude")]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -12,14 +12,49 @@ pub struct FileEntry {
   pub full_canonical_path: String,
 }
 
+#[cfg(not(feature = "include-exclude"))]
+pub fn is_path_included(_path: &str, _includes: &Vec<String>, _excludes: &Vec<String>) -> bool {
+  return true;
+}
+
+#[cfg(feature = "include-exclude")]
+pub fn is_path_included(rel_path: &str, includes: &Vec<String>, excludes: &Vec<String>) -> bool {
+  use glob::Pattern;
+
+  // ignore path matched by exclusion pattern
+  for exclude in excludes {
+    let pattern = Pattern::new(exclude).expect(&format!("invalid exclude pattern '{}'", exclude));
+
+    if pattern.matches(rel_path) {
+      return false;
+    }
+  }
+
+  // accept path if no includes provided
+  if includes.is_empty() {
+    return true;
+  }
+
+  // accept path if matched by inclusion pattern
+  for include in includes {
+    let pattern = Pattern::new(include).expect(&format!("invalid include pattern '{}'", include));
+
+    if pattern.matches(rel_path) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 #[cfg_attr(all(debug_assertions, not(feature = "debug-embed")), allow(unused))]
-pub fn get_files(folder_path: String) -> impl Iterator<Item = FileEntry> {
+pub fn get_files(folder_path: String, includes: Vec<String>, excludes: Vec<String>) -> impl Iterator<Item = FileEntry> {
   walkdir::WalkDir::new(&folder_path)
     .follow_links(true)
     .into_iter()
     .filter_map(|e| e.ok())
     .filter(|e| e.file_type().is_file())
-    .map(move |e| {
+    .filter_map(move |e| {
       let rel_path = path_to_str(e.path().strip_prefix(&folder_path).unwrap());
       let full_canonical_path = path_to_str(std::fs::canonicalize(e.path()).expect("Could not get canonical path"));
 
@@ -29,7 +64,11 @@ pub fn get_files(folder_path: String) -> impl Iterator<Item = FileEntry> {
         rel_path
       };
 
-      FileEntry { rel_path, full_canonical_path }
+      if is_path_included(&rel_path, &includes, &excludes) {
+        Some(FileEntry { rel_path, full_canonical_path })
+      } else {
+        None
+      }
     })
 }
 


### PR DESCRIPTION
Hi!

This PR adds a new feature - `includes-excludes`. With this feature enabled, we can specify multiple attributes with glob values, like `#[include = "*.txt"]` and `#[exclude = "tests/*"]`, for a fine-grained control over files embedded by `rust-embed`.

Example:
```rust
#[derive(RustEmbed)]
#[folder = "examples/public/"]
#[include = "*.html"]
#[include = "images/*"]
#[exclude = "*.txt"]
struct Asset;
```

It is related to #96 