### PR TITLE
Axum example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,11 @@ name = "rocket"
 path = "examples/rocket.rs"
 required-features = ["rocket"]
 
+[[example]]
+name = "axum"
+path = "examples/axum.rs"
+required-features = ["axum-ex"]
+
 [[test]]
 name = "interpolated_path"
 path = "tests/interpolated_path.rs"
@@ -44,9 +49,10 @@ rust-embed-utils = { version = "7.0.0", path = "utils"}
 include-flate = { version = "0.1", optional = true, features = ["stable"] }
 actix-web = { version = "3", default-features = false, optional = true }
 mime_guess = { version = "2", optional = true }
-tokio = { version = "0.2", optional = true, features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"], optional = true }
 warp = { version = "0.2", default-features = false, optional = true }
 rocket = { version = "0.4.5", default-features = false, optional = true }
+axum = { version = "0.2.3", default-features = false, optional = true  }
 
 [dev-dependencies]
 sha2 = "0.9"
@@ -59,6 +65,8 @@ include-exclude = ["rust-embed-impl/include-exclude"]
 nightly = ["rocket"]
 actix = ["actix-web", "mime_guess"]
 warp-ex = ["warp", "tokio", "mime_guess"]
+axum-ex = ["axum", "tokio", "mime_guess"]
+
 
 [badges]
 appveyor = { repository = "pyros2097/rust-embed" }

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -1,0 +1,63 @@
+use std::convert::Infallible;
+
+use axum::{
+  body::{Bytes, Full},
+  handler::get,
+  http::{header, Response, StatusCode, Uri},
+  response::{Html, IntoResponse},
+  routing::Router,
+};
+
+use axum::handler::Handler;
+use mime_guess;
+use rust_embed::RustEmbed;
+use std::net::SocketAddr;
+
+#[tokio::main]
+async fn main() {
+  // build our application with a route
+  let app = Router::new()
+    .route("/hello", get(helloworld))
+    // handle static files with rust_embed
+    .or(static_handler.into_service());
+
+  // run it
+  let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+  println!("listening on {}", addr);
+  axum::Server::bind(&addr).serve(app.into_make_service()).await.unwrap();
+}
+
+async fn helloworld() -> Html<&'static str> {
+  Html("<h1>Hello, World!</h1>")
+}
+
+async fn static_handler(uri: Uri) -> impl IntoResponse {
+  let path = uri.path().trim_start_matches('/').to_string();
+
+  StaticFile(path)
+}
+
+#[derive(RustEmbed)]
+#[folder = "examples/public/"]
+struct Asset;
+pub struct StaticFile<T>(pub T);
+
+impl<T> IntoResponse for StaticFile<T>
+where
+  T: Into<String>,
+{
+  type Body = Full<Bytes>;
+  type BodyError = Infallible;
+
+  fn into_response(self) -> Response<Self::Body> {
+    let path = self.0.into();
+    match Asset::get(path.as_str()) {
+      Some(content) => {
+        let body = content.data.into();
+        let mime = mime_guess::from_path(path).first_or_octet_stream();
+        Response::builder().header(header::CONTENT_TYPE, mime.as_ref()).body(body).unwrap()
+      }
+      None => Response::builder().status(StatusCode::NOT_FOUND).body(Full::from("404")).unwrap(),
+    }
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,10 @@ Note: To run the `warp` example:
 
 `cargo run --example warp --features warp-ex`
 
+Note: To run the `axum` example:
+
+`cargo run --example axum --features axum-ex`
+
 ## Testing
 
 debug: `cargo test --test lib`


### PR DESCRIPTION
example to use rust-embed with the brand new web framework [axum](https://github.com/tokio-rs/axum). 

i also updated tokio to version 1.0 which required by axum.

```toml
tokio = { version = "1.0", features = ["macros", "rt-multi-thread"], optional = true }
```