### PR TITLE
Use globset instead of glob

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,7 @@ Compress each file when embedding into the binary. Compression is done via [`inc
 
 ### `include-exclude`
 Filter files to be embedded with multiple `#[include = "*.txt"]` and `#[exclude = "*.jpg"]` attributes. 
-Matching is done on relative file paths, via [`glob`].
+Matching is done on relative file paths, via [`globset`].
 `exclude` attributes have higher priority than `include` attributes.
 Example:
 
@@ -177,4 +177,4 @@ Go Rusketeers!
 The power is yours!
 
 [`include-flate`]: https://crates.io/crates/include-flate
-[`glob`]: https://crates.io/crates/glob
+[`globset`]: https://crates.io/crates/globset

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -15,10 +15,10 @@ edition = "2018"
 walkdir = "2.3.1"
 sha2 = "0.9"
 
-[dependencies.glob]
+[dependencies.globset]
 version = "0.3.0"
 optional = true
 
 [features]
 debug-embed = []
-include-exclude = ["glob"]
+include-exclude = ["globset"]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -16,7 +16,7 @@ walkdir = "2.3.1"
 sha2 = "0.9"
 
 [dependencies.globset]
-version = "0.3.0"
+version = "0.4.8"
 optional = true
 
 [features]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -19,13 +19,15 @@ pub fn is_path_included(_path: &str, _includes: &[&str], _excludes: &[&str]) -> 
 
 #[cfg(feature = "include-exclude")]
 pub fn is_path_included(rel_path: &str, includes: &[&str], excludes: &[&str]) -> bool {
-  use glob::Pattern;
+  use globset::Glob;
 
   // ignore path matched by exclusion pattern
   for exclude in excludes {
-    let pattern = Pattern::new(exclude).unwrap_or_else(|_| panic!("invalid exclude pattern '{}'", exclude));
+    let pattern = Glob::new(exclude)
+      .unwrap_or_else(|_| panic!("invalid exclude pattern '{}'", exclude))
+      .compile_matcher();
 
-    if pattern.matches(rel_path) {
+    if pattern.is_match(rel_path) {
       return false;
     }
   }
@@ -37,9 +39,11 @@ pub fn is_path_included(rel_path: &str, includes: &[&str], excludes: &[&str]) ->
 
   // accept path if matched by inclusion pattern
   for include in includes {
-    let pattern = Pattern::new(include).unwrap_or_else(|_| panic!("invalid include pattern '{}'", include));
+    let pattern = Glob::new(include)
+      .unwrap_or_else(|_| panic!("invalid include pattern '{}'", include))
+      .compile_matcher();
 
-    if pattern.matches(rel_path) {
+    if pattern.is_match(rel_path) {
       return true;
     }
   }


### PR DESCRIPTION
Currently `glob` doesn't support [brace expansions](https://www.gnu.org/software/bash/manual/html_node/Brace-Expansion.html). Also, `**/` on `glob` will also match files rust-lang-nursery/glob#83, it could surprise some people if they were planning to use `**/` in their exclude attribute. So I changed `glob` dependency into `globset`.