### PR TITLE
Prevent path traversal attacks in debug mode

### DIFF
--- a/tests/path_traversal_attack.rs
+++ b/tests/path_traversal_attack.rs
@@ -1,0 +1,13 @@
+use rust_embed::RustEmbed;
+
+#[derive(RustEmbed)]
+#[folder = "examples/public/"]
+struct Assets;
+
+/// Prevent attempts to access files outside of the embedded folder.
+/// This is mainly a concern when running in debug mode, since that loads from
+/// the file system at runtime.
+#[test]
+fn path_traversal_attack_fails() {
+  assert!(Assets::get("../basic.rs").is_none());
+}


### PR DESCRIPTION
This is not a problem in release mode because we are in control of which files are loaded/embedded during compile time.

Fixes #159 