### PR TITLE
Remove `syn` features that are not required

### DIFF
--- a/impl/Cargo.toml
+++ b/impl/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 [dependencies]
 rust-embed-utils = { version = "7.1.0", path = "../utils"}
 
-syn = "1"
+syn = { version = "1", default-features = false, features = ["derive", "parsing", "proc-macro"] }
 quote = "1"
 proc-macro2 = "1"
 walkdir = "2.3.1"


### PR DESCRIPTION
The `impl` proc macro depends on `syn`. Not all of the features enabled in `syn`'s set of default features are required to build the `impl` proc macro.

Disable default features in the `syn` dependency and only enable the minimum set of features required to get the APIs needed by the `impl` crate. This has a nice side effect of slightly speeding up compile times.

Previously enabled default features `printing` and `clone-impls` are removed:

https://github.com/dtolnay/syn/blob/e23e46a06eb568a2ce32337e04002d35889870d0/Cargo.toml#L25